### PR TITLE
[FIX]: healthCheck root 경로로 변경

### DIFF
--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -18,7 +18,7 @@ echo "> Start health check of WAS at 'http://127.0.0.1:${TARGET_PORT}' ..."
 for RETRY_COUNT in 1 2 3 4 5 6 7 8 9 10
 do
     echo "> #${RETRY_COUNT} trying..."
-    RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}"  http://127.0.0.1:${TARGET_PORT}/test)
+    RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}"  http://127.0.0.1:${TARGET_PORT})
 
     if [ ${RESPONSE_CODE} -eq 200 ]; then
         echo "> New WAS successfully running"

--- a/src/main/java/org/sopt/makers/operation/controllers/HealthCheckController.java
+++ b/src/main/java/org/sopt/makers/operation/controllers/HealthCheckController.java
@@ -4,10 +4,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class TestController {
+public class HealthCheckController {
 
-	@GetMapping("/test")
+	@GetMapping("/")
 	public String healthCheck() {
-		return "server testV3";
+		return "Hello Operation!";
 	}
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #5

## Work Description ✏️
- Let's Encrypt를 통해 SSL을 붙이는 과정에서 문제가 발생함
- 루트 경로에 반환값을 설정해주지 않는 바람에 404를 띄우고 있어서 그럼
- Let's Encrypt가 루트 경로인 `operation.api.dev.sopt.org`에 요청했는데 404를 받아서 우리에게 발급해주지 않음
- 그래서 루트 경로가 200을 간단하게 반환하도록 변경함
- 근데 배포시에도 health_check를 하니까, 똑같은 것을 사용하면 될 것이라서 배포 스크립트도 수정해놓음 

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
너무 사소한것이라, 크게 받을 부분은 없을것 같아요! 문서화를 잘 해놓겠습니다!
