### PR TITLE
[FIX] 필드명 오류 수정

### DIFF
--- a/src/main/java/org/sopt/makers/operation/entity/SubSession.java
+++ b/src/main/java/org/sopt/makers/operation/entity/SubSession.java
@@ -31,16 +31,16 @@ public class SubSession {
 	@JoinColumn(name = "session_id")
 	private Session session;
 
-	private int order;
+	private int round;
 
 	private LocalDateTime startAt;
 
 	@OneToMany(mappedBy = "subSession")
 	private List<SubAttendance> subAttendances = new ArrayList<>();
 
-	public SubSession(Session session, int order, LocalDateTime startAt) {
+	public SubSession(Session session, int round, LocalDateTime startAt) {
 		this.session = session;
-		this.order = order;
+		this.round = round;
 		this.startAt = startAt;
 	}
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #15 

## Work Description ✏️
- `SubSession entity`의 컬럼명인 `order`를 `round`로 변경하였습니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- PostgreSQL에서 order라는 field를 사용하면 오류가 발생
- https://www.postgresql.org/docs/current/sql-keywords-appendix.html
- 따라서 대안으로 round라는 필드로 변경
