### PR TITLE
[CHORE] 공통 ApiResponse 추가

### DIFF
--- a/src/main/java/org/sopt/makers/operation/common/ApiResponse.java
+++ b/src/main/java/org/sopt/makers/operation/common/ApiResponse.java
@@ -10,6 +10,10 @@ public record ApiResponse(
 		return new ApiResponse(true, message, data);
 	}
 
+	public static ApiResponse success(String message) {
+		return new ApiResponse(true, message, null);
+	}
+
 	public static ApiResponse fail(String message) {
 		return new ApiResponse(false, message, null);
 	}

--- a/src/main/java/org/sopt/makers/operation/common/ApiResponse.java
+++ b/src/main/java/org/sopt/makers/operation/common/ApiResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.operation.common;
+
+public record ApiResponse(
+	boolean success,
+	String message,
+	Object data
+) {
+
+	public static ApiResponse success(String message, Object data) {
+		return new ApiResponse(true, message, data);
+	}
+
+	public static ApiResponse fail(String message) {
+		return new ApiResponse(false, message, null);
+	}
+}


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
closed #19 

## Work Description ✏️
- success와 fail 응답 데이터 형식을 지정했습니다.
- success 사용 방식
  ```
	@GetMapping("/test/success")
	public ResponseEntity<Object> testSuccessApiResponse() {
		ApiResponse response = ApiResponse.success("test message", "data");
		return ResponseEntity.ok(response);
	}
  ```
  <img width="1068" alt="image" src="https://user-images.githubusercontent.com/55437339/229343854-d36c3a45-06a6-448b-b360-cac378355c11.png">

- fail 사용 방식 (예외처리 컨트롤러에서 해당 방식 적용이 필요합니다.)
  ```
	@GetMapping("/test/fail")
	public ResponseEntity<Object> testFailApiResponse() {
		ApiResponse response = ApiResponse.fail("test message");
		return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
	}
  ```
  <img width="1025" alt="image" src="https://user-images.githubusercontent.com/55437339/229343874-6bda0072-652f-4e27-86c6-32b679cd7675.png">


## PR Point 📸
- 기존 SOPT에서 사용하던 응답 메세지에서 status 코드는 응답 메세지에 포함시키지 않아도 전달할 수 있어서 제외했습니다.
- 그 외에 성공 여부(success), 응답 메세지(message), 응답 데이터(data) 항목을 포함했습니다.
