### PR TITLE
[FIX] 출석 상태 게산 로직 변경

### DIFF
--- a/src/main/java/org/sopt/makers/operation/dto/attendance/AttendanceResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/attendance/AttendanceResponseDTO.java
@@ -1,11 +1,13 @@
 package org.sopt.makers.operation.dto.attendance;
 
 import org.sopt.makers.operation.entity.AttendanceStatus;
+import org.sopt.makers.operation.entity.SubAttendance;
 
 public record AttendanceResponseDTO(
-	Long memberId,
-	AttendanceStatus status,
-	float score,
-	float totalScore
+	Long subAttendanceId,
+	AttendanceStatus status
 ) {
+	public static AttendanceResponseDTO of(SubAttendance subAttendance) {
+		return new AttendanceResponseDTO(subAttendance.getId(), subAttendance.getStatus());
+	}
 }

--- a/src/main/java/org/sopt/makers/operation/dto/lecture/LectureResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/lecture/LectureResponseDTO.java
@@ -42,8 +42,7 @@ record MemberVO(
 ) {
 	static MemberVO of(Attendance attendance) {
 		List<MemberAttendanceVO> attendances = attendance.getSubAttendances()
-			.stream()
-			.map(MemberAttendanceVO::of)
+			.stream().map(MemberAttendanceVO::of)
 			.toList();
 
 		float score = 0;
@@ -60,15 +59,11 @@ record MemberVO(
 	}
 
 	private static float getScore(Attribute attribute, List<MemberAttendanceVO> attendances) {
-		switch (attribute) {
-			case SEMINAR -> {
-				return getResultInSeminar32(attendances.get(0).status(), attendances.get(1).status());
-			}
-			case EVENT -> {
-				return getResultInEvent32(attendances.get(1).status());
-			}
-		}
-		return 0;
+		return switch (attribute) {
+			case SEMINAR -> getResultInSeminar32(attendances.get(0).status(), attendances.get(1).status());
+			case EVENT -> getResultInEvent32(attendances.get(1).status());
+			case ETC -> 0;
+		};
 	}
 
 	private static float getResultInSeminar32 (AttendanceStatus first, AttendanceStatus second) {

--- a/src/main/java/org/sopt/makers/operation/entity/Attendance.java
+++ b/src/main/java/org/sopt/makers/operation/entity/Attendance.java
@@ -51,6 +51,10 @@ public class Attendance {
 		this.status = AttendanceStatus.ABSENT;
 	}
 
+	public void updateStatus(AttendanceStatus status) {
+		this.status = status;
+	}
+
 	private void setMember(Member member) {
 		if (Objects.nonNull(this.member)) {
 			this.member.getAttendances().remove(this);

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
@@ -66,6 +66,7 @@ public class AttendanceServiceImpl implements AttendanceService {
 
 	private AttendanceResponseDTO updateMemberScoreInSeminar(SubAttendance subAttendance) {
 		AttendanceStatus status = getStatusIn32Seminar(subAttendance.getAttendance().getSubAttendances());
+		subAttendance.getAttendance().updateStatus(status);
 		Member member = subAttendance.getAttendance().getMember();
 		float score = getScoreIn32Seminar(status);
 		member.updateScore(score);
@@ -74,6 +75,7 @@ public class AttendanceServiceImpl implements AttendanceService {
 
 	private AttendanceResponseDTO updateMemberScoreInEvent(SubAttendance subAttendance) {
 		AttendanceStatus status = getStatusIn32Event(subAttendance.getAttendance().getSubAttendances());
+		subAttendance.getAttendance().updateStatus(status);
 		Member member = subAttendance.getAttendance().getMember();
 		float score = getScoreIn32Event(status);
 		member.updateScore(score);

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
@@ -39,21 +39,22 @@ public class AttendanceServiceImpl implements AttendanceService {
 		subAttendance.updateStatus(requestDTO.status());
 
 		Attendance attendance = subAttendance.getAttendance();
-		SubLecture subLecture = subAttendance.getSubLecture();
 		Member member = attendance.getMember();
 
-		if (attendance.getSubAttendances().size() == subLecture.getRound()) {
-			switch (requestDTO.attribute()) {
-				case SEMINAR -> {
-					return updateMemberScoreInSeminar(subAttendance);
-				}
-				case EVENT -> {
-					return updateMemberScoreInEvent(subAttendance);
-				}
+		switch (requestDTO.attribute()) {
+			case SEMINAR -> {
+				return updateMemberScoreInSeminar(subAttendance);
+			}
+			case EVENT -> {
+				return updateMemberScoreInEvent(subAttendance);
 			}
 		}
 
-		return new AttendanceResponseDTO(member.getId(), ABSENT, 0, member.getScore());
+		return new AttendanceResponseDTO(
+			member.getId(),
+			getStatusIn32Seminar(attendance.getSubAttendances()),
+			0,
+			member.getScore());
 	}
 
 	@Override
@@ -103,11 +104,11 @@ public class AttendanceServiceImpl implements AttendanceService {
 
 	private AttendanceStatus getStatusIn32Seminar(List<SubAttendance> attendances) {
 		if (attendances.get(0).getStatus().equals(ATTENDANCE) && attendances.get(1).getStatus().equals(ATTENDANCE)) {
-			return ATTENDANCE; // 0
+			return ATTENDANCE;
 		} else if (attendances.get(0).getStatus().equals(ABSENT) && attendances.get(1).getStatus().equals(ATTENDANCE)) {
-			return TARDY; // -0.5
+			return TARDY;
 		}
-		return ABSENT; // -1
+		return ABSENT;
 	}
 
 	private AttendanceStatus getStatusIn32Event(List<SubAttendance> attendances) {

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
@@ -1,21 +1,14 @@
 package org.sopt.makers.operation.service;
 
 import static org.sopt.makers.operation.common.ExceptionMessage.*;
-import static org.sopt.makers.operation.entity.AttendanceStatus.*;
-
-import java.util.List;
 
 import javax.persistence.EntityNotFoundException;
 
-import org.sopt.makers.operation.common.ExceptionMessage;
 import org.sopt.makers.operation.dto.attendance.AttendanceMemberResponseDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceRequestDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceResponseDTO;
-import org.sopt.makers.operation.entity.Attendance;
-import org.sopt.makers.operation.entity.AttendanceStatus;
 import org.sopt.makers.operation.entity.Member;
 import org.sopt.makers.operation.entity.SubAttendance;
-import org.sopt.makers.operation.entity.SubLecture;
 import org.sopt.makers.operation.repository.SubAttendanceRepository;
 import org.sopt.makers.operation.repository.member.MemberRepository;
 import org.springframework.stereotype.Service;
@@ -34,86 +27,24 @@ public class AttendanceServiceImpl implements AttendanceService {
 	@Override
 	@Transactional
 	public AttendanceResponseDTO updateAttendanceStatus(AttendanceRequestDTO requestDTO) {
-		SubAttendance subAttendance = subAttendanceRepository.findById(requestDTO.subAttendanceId())
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_ATTENDANCE.getName()));
+		SubAttendance subAttendance = findSubAttendance(requestDTO.subAttendanceId());
 		subAttendance.updateStatus(requestDTO.status());
-
-		Attendance attendance = subAttendance.getAttendance();
-		Member member = attendance.getMember();
-
-		switch (requestDTO.attribute()) {
-			case SEMINAR -> {
-				return updateMemberScoreInSeminar(subAttendance);
-			}
-			case EVENT -> {
-				return updateMemberScoreInEvent(subAttendance);
-			}
-		}
-
-		return new AttendanceResponseDTO(
-			member.getId(),
-			getStatusIn32Seminar(attendance.getSubAttendances()),
-			0,
-			member.getScore());
+		return AttendanceResponseDTO.of(subAttendance);
 	}
 
 	@Override
 	public AttendanceMemberResponseDTO getMemberAttendance(Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_MEMBER.getName()));
+		Member member = findMember(memberId);
 		return AttendanceMemberResponseDTO.of(member);
 	}
 
-	private AttendanceResponseDTO updateMemberScoreInSeminar(SubAttendance subAttendance) {
-		AttendanceStatus status = getStatusIn32Seminar(subAttendance.getAttendance().getSubAttendances());
-		subAttendance.getAttendance().updateStatus(status);
-		Member member = subAttendance.getAttendance().getMember();
-		float score = getScoreIn32Seminar(status);
-		member.updateScore(score);
-		return new AttendanceResponseDTO(member.getId(), status, score, member.getScore());
+	private Member findMember(Long id) {
+		return memberRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException(INVALID_MEMBER.getName()));
 	}
 
-	private AttendanceResponseDTO updateMemberScoreInEvent(SubAttendance subAttendance) {
-		AttendanceStatus status = getStatusIn32Event(subAttendance.getAttendance().getSubAttendances());
-		subAttendance.getAttendance().updateStatus(status);
-		Member member = subAttendance.getAttendance().getMember();
-		float score = getScoreIn32Event(status);
-		member.updateScore(score);
-		return new AttendanceResponseDTO(member.getId(), status, score, member.getScore());
-	}
-
-	private float getScoreIn32Seminar(AttendanceStatus status) {
-		switch (status) {
-			case ATTENDANCE -> {
-				return 0;
-			}
-			case TARDY -> {
-				return -0.5f;
-			}
-			case ABSENT -> {
-				return -1;
-			}
-		}
-		return 0;
-	}
-
-	private float getScoreIn32Event(AttendanceStatus status) {
-		if (status.equals(ATTENDANCE)) {
-			return 0.5f;
-		}
-		return 0;
-	}
-
-	private AttendanceStatus getStatusIn32Seminar(List<SubAttendance> attendances) {
-		if (attendances.get(0).getStatus().equals(ATTENDANCE) && attendances.get(1).getStatus().equals(ATTENDANCE)) {
-			return ATTENDANCE;
-		} else if (attendances.get(0).getStatus().equals(ABSENT) && attendances.get(1).getStatus().equals(ATTENDANCE)) {
-			return TARDY;
-		}
-		return ABSENT;
-	}
-
-	private AttendanceStatus getStatusIn32Event(List<SubAttendance> attendances) {
-		return attendances.get(1).getStatus().equals(ATTENDANCE) ? ATTENDANCE : ABSENT;
+	private SubAttendance findSubAttendance(Long id) {
+		return subAttendanceRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException(INVALID_ATTENDANCE.getName()));
 	}
 }

--- a/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
@@ -101,9 +101,8 @@ public class LectureServiceImpl implements LectureService {
 		Attendance attendance = attendanceRepository.findAttendanceByLectureIdAndMemberId(currentSession.getId(), lectureSearchCondition.memberId());
 
 		List<LectureGetResponseVO> attendances = attendance.getSubAttendances().stream()
-				.map(subAttendance -> {
-					return LectureGetResponseVO.of(subAttendance.getStatus(), subAttendance.getLastModifiedDate());
-				})
+				.map(subAttendance -> LectureGetResponseVO
+					.of(subAttendance.getStatus(), subAttendance.getLastModifiedDate()))
 				.collect(Collectors.toList());
 
 		return LectureGetResponseDTO.of(type, currentSession, attendances);
@@ -120,8 +119,7 @@ public class LectureServiceImpl implements LectureService {
 
 	@Override
 	public LectureResponseDTO getLecture(Long lectureId, Part part) {
-		Lecture lecture = lectureRepository.findById(lectureId)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_LECTURE.getName()));
+		Lecture lecture = findLecture(lectureId);
 		List<Attendance> attendances = attendanceRepository.getAttendanceByPart(lecture, part);
 		return LectureResponseDTO.of(lecture, attendances);
 	}
@@ -129,8 +127,7 @@ public class LectureServiceImpl implements LectureService {
 	@Override
 	@Transactional
 	public AttendanceResponseDTO startAttendance(AttendanceRequestDTO requestDTO) {
-		Lecture lecture = lectureRepository.findById(requestDTO.lectureId())
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_LECTURE.getName()));
+		Lecture lecture = findLecture(requestDTO.lectureId());
 
 		for (SubLecture subLecture : lecture.getSubLectures()) {
 			if (subLecture.getRound() < requestDTO.round() && subLecture.getStartAt() == null) {
@@ -142,6 +139,11 @@ public class LectureServiceImpl implements LectureService {
 		}
 
 		throw new IllegalStateException(INVALID_LECTURE.getName());
+	}
+
+	private Lecture findLecture(Long id) {
+		return lectureRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException(INVALID_LECTURE.getName()));
 	}
 
 	private LectureVO getLectureVO(Lecture lecture) {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
closed #48 

## Work Description ✏️
- N차 출석 상태를 변경할 때, 해당 전체 출석 상태를 업데이트하는 로직을 추가했습니다.
- 기존 2차 출석을 변경해야만 유저의 점수를 변경했던 로직에서 -> 출석 변경만 하면 유저의 점수를 변경하는 로직으로 변경했습니다.

## PR Point 📸
<img width="326" alt="image" src="https://user-images.githubusercontent.com/55437339/230698631-513d5d1b-24b4-43ee-b0ee-6ec7c7bb8db3.png">
로직 수정하는 김에 switch 문에서 {}을 제외했는데 요렇게 뜨더라구요ㅠㅠ 전에 코드리뷰 중 말한 사항입니다!