### PR TITLE
[FEAT] 유저 출석 점수 갱신 기능 구현

### DIFF
--- a/src/main/java/org/sopt/makers/operation/controller/AttendanceController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/AttendanceController.java
@@ -59,4 +59,11 @@ public class AttendanceController {
 		AttendanceMemberResponseDTO response = attendanceService.getMemberAttendance(memberId);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_MEMBER_ATTENDANCE.getMessage(), response));
 	}
+
+	@PatchMapping("/member/{memberId}")
+	public ResponseEntity<ApiResponse> updateMemberScore(Principal principal, @PathVariable Long memberId) {
+		adminService.confirmAdmin(Long.valueOf(principal.getName()));
+		float response = attendanceService.updateMemberScore(memberId);
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_MEMBER_SCORE.getMessage(), response));
+	}
 }

--- a/src/main/java/org/sopt/makers/operation/entity/Member.java
+++ b/src/main/java/org/sopt/makers/operation/entity/Member.java
@@ -59,4 +59,7 @@ public class Member {
 	public void updateScore(float score) {
 		this.score += score;
 	}
+	public void setScore(float score) {
+		this.score = score;
+	}
 }

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceService.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceService.java
@@ -3,9 +3,9 @@ package org.sopt.makers.operation.service;
 import org.sopt.makers.operation.dto.attendance.AttendanceMemberResponseDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceRequestDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceResponseDTO;
-import org.sopt.makers.operation.entity.Member;
 
 public interface AttendanceService {
 	AttendanceResponseDTO updateAttendanceStatus(AttendanceRequestDTO requestDTO);
 	AttendanceMemberResponseDTO getMemberAttendance(Long memberId);
+	float updateMemberScore(Long memberId);
 }

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
@@ -46,10 +46,9 @@ public class AttendanceServiceImpl implements AttendanceService {
 	@Transactional
 	public float updateMemberScore(Long memberId) {
 		Member member = findMember(memberId);
-		float score = 2;
-		for (Attendance attendance : member.getAttendances()) {
-			score += getUpdateScore(attendance, attendance.getLecture().getAttribute());
-		}
+		float score = (float)(2 + member.getAttendances().stream()
+			.mapToDouble(attendance -> getUpdateScore(attendance, attendance.getLecture().getAttribute()))
+			.sum());
 		member.setScore(score);
 		return member.getScore();
 	}

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
@@ -1,14 +1,18 @@
 package org.sopt.makers.operation.service;
 
 import static org.sopt.makers.operation.common.ExceptionMessage.*;
+import static org.sopt.makers.operation.entity.AttendanceStatus.*;
+import static org.sopt.makers.operation.entity.lecture.Attribute.*;
 
 import javax.persistence.EntityNotFoundException;
 
 import org.sopt.makers.operation.dto.attendance.AttendanceMemberResponseDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceRequestDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceResponseDTO;
+import org.sopt.makers.operation.entity.Attendance;
 import org.sopt.makers.operation.entity.Member;
 import org.sopt.makers.operation.entity.SubAttendance;
+import org.sopt.makers.operation.entity.lecture.Attribute;
 import org.sopt.makers.operation.repository.SubAttendanceRepository;
 import org.sopt.makers.operation.repository.member.MemberRepository;
 import org.springframework.stereotype.Service;
@@ -36,6 +40,33 @@ public class AttendanceServiceImpl implements AttendanceService {
 	public AttendanceMemberResponseDTO getMemberAttendance(Long memberId) {
 		Member member = findMember(memberId);
 		return AttendanceMemberResponseDTO.of(member);
+	}
+
+	@Override
+	@Transactional
+	public float updateMemberScore(Long memberId) {
+		Member member = findMember(memberId);
+		float score = 2;
+		for (Attendance attendance : member.getAttendances()) {
+			score += getUpdateScore(attendance, attendance.getLecture().getAttribute());
+		}
+		member.setScore(score);
+		return member.getScore();
+	}
+
+	private float getUpdateScore(Attendance attendance, Attribute attribute) {
+		if (attribute.equals(SEMINAR)) {
+			if (attendance.getStatus().equals(TARDY)) {
+				return -0.5f;
+			} else if (attendance.getStatus().equals(ABSENT)) {
+				return -1;
+			}
+		} else if (attribute.equals(EVENT)) {
+			if (attendance.getStatus().equals(ATTENDANCE)) {
+				return 0.5f;
+			}
+		}
+		return 0;
 	}
 
 	private Member findMember(Long id) {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
closed #63 

## Work Description ✏️
- 유저 출석 점수를 전체 갱신하는 트리거 역할하는 API를 구현했습니다.

