### PR TITLE
[FIX] 단일 세미나 로직 변경

### DIFF
--- a/src/main/java/org/sopt/makers/operation/dto/lecture/LectureGetResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/lecture/LectureGetResponseDTO.java
@@ -12,9 +12,10 @@ public record LectureGetResponseDTO(
         String name,
         String startDate,
         String endDate,
+        String message,
         List<LectureGetResponseVO> attendances
 ) {
-    public static LectureGetResponseDTO of(LectureResponseType type, Lecture lecture, List<LectureGetResponseVO> attendances) {
+    public static LectureGetResponseDTO of(LectureResponseType type, Lecture lecture, String message, List<LectureGetResponseVO> attendances) {
 
         return new LectureGetResponseDTO(
                 type,
@@ -22,6 +23,7 @@ public record LectureGetResponseDTO(
                 lecture.getName(),
                 lecture.getStartDate().format(convertFormat()),
                 lecture.getEndDate().format(convertFormat()),
+                message,
                 attendances
         );
     }

--- a/src/main/java/org/sopt/makers/operation/dto/lecture/LectureGetResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/lecture/LectureGetResponseDTO.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 public record LectureGetResponseDTO(
         LectureResponseType type,
+        Long id,
         String location,
         String name,
         String startDate,
@@ -19,6 +20,7 @@ public record LectureGetResponseDTO(
 
         return new LectureGetResponseDTO(
                 type,
+                lecture.getId(),
                 lecture.getPlace(),
                 lecture.getName(),
                 lecture.getStartDate().format(convertFormat()),

--- a/src/main/java/org/sopt/makers/operation/service/LectureService.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureService.java
@@ -17,7 +17,6 @@ public interface LectureService {
 	LecturesResponseDTO getLecturesByGeneration(int generation);
 	LectureResponseDTO getLecture(Long lectureId, Part part);
 	AttendanceResponseDTO startAttendance(AttendanceRequestDTO requestDTO);
-	AttendanceTotalResponseDTO getTotal(Member member);
 	void updateMembersScore(Long lectureId);
 
 }

--- a/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
@@ -4,13 +4,12 @@ import static org.sopt.makers.operation.common.ExceptionMessage.*;
 import static org.sopt.makers.operation.entity.AttendanceStatus.*;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.sopt.makers.operation.dto.attendance.AttendanceTotalCountVO;
-import org.sopt.makers.operation.dto.attendance.AttendanceTotalResponseDTO;
+import lombok.val;
+
 import org.sopt.makers.operation.dto.attendance.AttendanceTotalVO;
 import org.sopt.makers.operation.dto.lecture.*;
 import javax.persistence.EntityNotFoundException;
@@ -26,6 +25,7 @@ import org.sopt.makers.operation.dto.member.MemberSearchCondition;
 import org.sopt.makers.operation.entity.*;
 import org.sopt.makers.operation.entity.lecture.Attribute;
 import org.sopt.makers.operation.entity.lecture.Lecture;
+import org.sopt.makers.operation.exception.LectureException;
 import org.sopt.makers.operation.repository.attendance.AttendanceRepository;
 import org.sopt.makers.operation.repository.SubAttendanceRepository;
 import org.sopt.makers.operation.repository.lecture.LectureRepository;
@@ -72,40 +72,43 @@ public class LectureServiceImpl implements LectureService {
 
 	@Override
 	public LectureGetResponseDTO getCurrentLecture(LectureSearchCondition lectureSearchCondition) {
-		LocalDateTime now = LocalDateTime.now();
+		val now = LocalDateTime.now();
+		val sessionNumber = (now.getHour() < 16) ? 2 : 3;
+		val lectures = lectureRepository.searchLecture(lectureSearchCondition);
 
-		List<Lecture> lectures = lectureRepository.searchLecture(lectureSearchCondition);
+		if (lectures.size() > 2) throw new LectureException("세션의 개수가 올바르지 않습니다");
 
 		// 세션이 없을 때
 		if (lectures.isEmpty()) {
-			return new LectureGetResponseDTO(LectureResponseType.NO_SESSION, "", "", "", "", Collections.emptyList());
+			return new LectureGetResponseDTO(LectureResponseType.NO_SESSION, "", "", "", "", "", Collections.emptyList());
 		}
 
 		Lecture currentSession;
 		LectureResponseType type;
 
-		// 하루에 세션이 하나일 때, 하루에 세션이 여러개일 때
 		if (lectures.size() == 1) {
 			currentSession = lectures.get(0);
-			type = (currentSession.getAttribute() == Attribute.SEMINAR) ? LectureResponseType.HAS_ATTENDANCE : LectureResponseType.NO_ATTENDANCE;
+			type = (currentSession.getAttribute() != Attribute.ETC) ? LectureResponseType.HAS_ATTENDANCE : LectureResponseType.NO_ATTENDANCE;
 		} else {
-			int sessionNumber = (now.getHour() < 16) ? 2 : 3;
-			type = (sessionNumber == 3) ? LectureResponseType.NO_ATTENDANCE : LectureResponseType.HAS_ATTENDANCE;
 			currentSession = lectures.get(sessionNumber - 2);
+			type = (sessionNumber == 3) ? LectureResponseType.NO_ATTENDANCE : LectureResponseType.HAS_ATTENDANCE;
 		}
 
-		if(type.equals(LectureResponseType.NO_ATTENDANCE)) {
-			return LectureGetResponseDTO.of(type, currentSession, Collections.emptyList());
+		if (type.equals(LectureResponseType.NO_ATTENDANCE)) {
+			val message = "출석 점수가 반영되지 않아요.";
+			return LectureGetResponseDTO.of(type, currentSession, message, Collections.emptyList());
 		}
 
 		// 출결 가져오기
-		Attendance attendance = attendanceRepository.findAttendanceByLectureIdAndMemberId(currentSession.getId(), lectureSearchCondition.memberId());
+		val attendance = attendanceRepository.findAttendanceByLectureIdAndMemberId(currentSession.getId(), lectureSearchCondition.memberId());
 
-		List<LectureGetResponseVO> attendances = attendance.getSubAttendances().stream()
+		val attendances = attendance.getSubAttendances().stream()
 				.map(subAttendance -> LectureGetResponseVO.of(subAttendance.getStatus(), subAttendance.getLastModifiedDate()))
 				.collect(Collectors.toList());
 
-		return LectureGetResponseDTO.of(type, currentSession, attendances);
+		val message = (currentSession.getAttribute() == Attribute.SEMINAR) ? "" : "행사도 참여하고, 출석점수도 받고, 일석이조!";
+
+		return LectureGetResponseDTO.of(type, currentSession, message, attendances);
 	}
 
 
@@ -139,30 +142,6 @@ public class LectureServiceImpl implements LectureService {
 		}
 
 		throw new IllegalStateException(INVALID_LECTURE.getName());
-	}
-
-	@Override
-	public AttendanceTotalResponseDTO getTotal(Member member) {
-		List<AttendanceTotalVO> attendances = attendanceRepository.findAttendanceByMemberId(member.getId())
-			.stream().map(this::getTotalAttendanceVO)
-			.toList();
-
-		Map<AttendanceStatus, Integer> countAttendance = attendances.stream()
-			.map(this::getAttendanceStatus)
-			.collect(
-				() -> new EnumMap<>(AttendanceStatus.class),
-				(map, status) -> map.merge(status, 1, Integer::sum),
-				(map1, map2) -> map2.forEach((status, count) -> map1.merge(status, count, Integer::sum))
-			);
-
-		AttendanceTotalCountVO total = AttendanceTotalCountVO.of(
-			countAttendance.size(),
-			countAttendance.getOrDefault(ATTENDANCE, 0),
-			countAttendance.getOrDefault(AttendanceStatus.ABSENT, 0),
-			countAttendance.getOrDefault(AttendanceStatus.TARDY, 0)
-		);
-
-		return AttendanceTotalResponseDTO.of(member, total, attendances);
 	}
 
 	@Override


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #71 

## Work Description ✏️
- ETC, 행사일시 메세지를 추가로 반환합니다
- 출석 점수가 반영되지 않아요. / 행사도 참여하고, 출석점수도 받고, 일석이조!
- 행사시에도 출석 정보 반환하도록함
- val 사용

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- val을 사용하고 싶은데, 케이스마다 구분된 (세미나 1개인날, 2개인날(솝커톤-세미나)) scope 안에서 재할당해야하는 변수들이라 final인 val이 안먹습니다. val을 사용하면서 깔끔하게 할 방법이 있을까요?
```
Lecture currentSession;
LectureResponseType type;
```