### PR TITLE
[ADD] 출석 상태 변경 로직 추가

### DIFF
--- a/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
@@ -15,6 +15,7 @@ import org.sopt.makers.operation.entity.SubAttendance;
 import org.sopt.makers.operation.entity.lecture.Attribute;
 import org.sopt.makers.operation.repository.SubAttendanceRepository;
 import org.sopt.makers.operation.repository.member.MemberRepository;
+import org.sopt.makers.operation.util.Generation32;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,12 +28,15 @@ public class AttendanceServiceImpl implements AttendanceService {
 
 	private final SubAttendanceRepository subAttendanceRepository;
 	private final MemberRepository memberRepository;
+	private final Generation32 sopt32;
 
 	@Override
 	@Transactional
 	public AttendanceResponseDTO updateAttendanceStatus(AttendanceRequestDTO requestDTO) {
 		SubAttendance subAttendance = findSubAttendance(requestDTO.subAttendanceId());
 		subAttendance.updateStatus(requestDTO.status());
+		Attendance attendance = subAttendance.getAttendance();
+		attendance.updateStatus(sopt32.getAttendanceStatus(requestDTO.attribute(), attendance.getSubAttendances()));
 		return AttendanceResponseDTO.of(subAttendance);
 	}
 

--- a/src/main/java/org/sopt/makers/operation/util/Generation32.java
+++ b/src/main/java/org/sopt/makers/operation/util/Generation32.java
@@ -1,0 +1,48 @@
+package org.sopt.makers.operation.util;
+
+import static org.sopt.makers.operation.entity.AttendanceStatus.*;
+
+import java.util.List;
+
+import org.sopt.makers.operation.entity.AttendanceStatus;
+import org.sopt.makers.operation.entity.SubAttendance;
+import org.sopt.makers.operation.entity.lecture.Attribute;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Generation32 {
+
+	public AttendanceStatus getAttendanceStatus(Attribute attribute, List<SubAttendance> subAttendances) {
+		int firstRound = subAttendances.get(0).getSubLecture().getRound() == 1 ? 0 : 1;
+		SubAttendance first = subAttendances.get(firstRound);
+		SubAttendance second = subAttendances.get(1 - firstRound);
+		return switch (attribute) {
+			case SEMINAR -> getAttendanceStatusInSeminar(first, second);
+			case EVENT -> getAttendanceStatusInEvent(second);
+			case ETC -> getAttendanceStatusInEtc(second);
+		};
+	}
+
+	private AttendanceStatus getAttendanceStatusInSeminar(SubAttendance first, SubAttendance second) {
+		if (first.getStatus().equals(ATTENDANCE) && second.getStatus().equals(ATTENDANCE)) {
+			return ATTENDANCE;
+		} else if (first.getStatus().equals(ABSENT) && second.getStatus().equals(ATTENDANCE)) {
+			return TARDY;
+		}
+		return ABSENT;
+	}
+
+	private AttendanceStatus getAttendanceStatusInEvent(SubAttendance second) {
+		if (second.getStatus().equals(ATTENDANCE)) {
+			return ATTENDANCE;
+		}
+		return ABSENT;
+	}
+
+	private AttendanceStatus getAttendanceStatusInEtc(SubAttendance second) {
+		if (second.getStatus().equals(ATTENDANCE)) {
+			return PARTICIPATE;
+		}
+		return NOT_PARTICIPATE;
+	}
+}


### PR DESCRIPTION
## Related Issue 🚀
closed #64 

## Work Description ✏️
- N차 출석 상태 변경 시, 출석(Attendance) 상태 변경 로직을 추가했습니다.

## PR Point 📸
출석 상태를 판단하는 로직이 끊임없이 나올 것 같아서 util.Generation32 클래스를 생성하고 해당 로직을 추가했습니다.
아래 로직이 괜찮다면, 리팩토링 기간에 퍼져있는 같은 로직 수습 좀 하겠읍니다 😇
```
	public AttendanceStatus getAttendanceStatus(Attribute attribute, List<SubAttendance> subAttendances) {
		int firstRound = subAttendances.get(0).getSubLecture().getRound() == 1 ? 0 : 1;
		SubAttendance first = subAttendances.get(firstRound);
		SubAttendance second = subAttendances.get(1 - firstRound);
		return switch (attribute) {
			case SEMINAR -> getAttendanceStatusInSeminar(first, second);
			case EVENT -> getAttendanceStatusInEvent(second);
			case ETC -> getAttendanceStatusInEtc(second);
		};
	}
```

또한, 현재 해당 로직(출석 상태 변경)에서 쿼리가 6개까지 나가고 있어요 ㅠㅅㅠ 리팩토링 기간에 최적화 방안까지 생각해보도록 하겟읍니다..