### PR TITLE
[FIX] 세션 상세 조회 API 분리

### DIFF
--- a/src/main/java/org/sopt/makers/operation/common/ResponseMessage.java
+++ b/src/main/java/org/sopt/makers/operation/common/ResponseMessage.java
@@ -16,7 +16,8 @@ public enum ResponseMessage {
 	SUCCESS_GET_MEMBER_ATTENDANCE("회원 출석 정보 조회 성공"),
 	SUCCESS_GET_ATTENDANCE_SCORE("출석 점수 조회 성공"),
 	SUCCESS_UPDATE_MEMBER_SCORE("회원 출석 점수 갱신 성공"),
-	SUCCESS_GET_MEMBERS("유저 리스트 조회 성공");
+	SUCCESS_GET_MEMBERS("유저 리스트 조회 성공"),
+	SUCCESS_GET_ATTENDANCES("출석 리스트 조회 성공");
 
 	private final String message;
 }

--- a/src/main/java/org/sopt/makers/operation/controller/AttendanceController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/AttendanceController.java
@@ -3,19 +3,24 @@ package org.sopt.makers.operation.controller;
 import static org.sopt.makers.operation.common.ResponseMessage.*;
 
 import java.security.Principal;
+import java.util.List;
 
 import org.sopt.makers.operation.common.ApiResponse;
 import org.sopt.makers.operation.dto.attendance.AttendanceMemberResponseDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceRequestDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceResponseDTO;
+import org.sopt.makers.operation.dto.attendance.MemberResponseDTO;
+import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.service.AdminService;
 import org.sopt.makers.operation.service.AttendanceService;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.ApiOperation;
@@ -65,5 +70,13 @@ public class AttendanceController {
 		adminService.confirmAdmin(Long.valueOf(principal.getName()));
 		float response = attendanceService.updateMemberScore(memberId);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_MEMBER_SCORE.getMessage(), response));
+	}
+
+	@ApiOperation(value = "세션별 출석 정보 조회")
+	@GetMapping("lecture/{lectureId}")
+	public ResponseEntity<ApiResponse> getAttendancesByLecture(
+		@PathVariable Long lectureId, @RequestParam(required = false) Part part, Pageable pageable) {
+		List<MemberResponseDTO> response = attendanceService.getMemberAttendances(lectureId, part, pageable);
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ATTENDANCES.getMessage(), response));
 	}
 }

--- a/src/main/java/org/sopt/makers/operation/controller/LectureController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/LectureController.java
@@ -1,25 +1,18 @@
 package org.sopt.makers.operation.controller;
 
-import static org.sopt.makers.operation.common.ExceptionMessage.INVALID_MEMBER;
 import static org.sopt.makers.operation.common.ResponseMessage.*;
 
 import java.net.URI;
 import java.security.Principal;
 
 import org.sopt.makers.operation.common.ApiResponse;
-<<<<<<< HEAD
 import org.sopt.makers.operation.dto.lecture.AttendanceRequestDTO;
 import org.sopt.makers.operation.dto.lecture.AttendanceResponseDTO;
 import org.sopt.makers.operation.dto.lecture.LectureRequestDTO;
 import org.sopt.makers.operation.dto.lecture.LectureResponseDTO;
 import org.sopt.makers.operation.dto.lecture.LecturesResponseDTO;
-=======
-import org.sopt.makers.operation.dto.lecture.*;
-import org.sopt.makers.operation.entity.Part;
->>>>>>> develop
 import org.sopt.makers.operation.service.AdminService;
 import org.sopt.makers.operation.service.LectureService;
-import org.sopt.makers.operation.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -42,7 +35,6 @@ public class LectureController {
 
 	private final AdminService adminService;
 	private final LectureService lectureService;
-	private final MemberService memberService;
 
 	@ApiOperation(value = "세션 생성")
 	@ApiResponses({

--- a/src/main/java/org/sopt/makers/operation/controller/LectureController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/LectureController.java
@@ -11,7 +11,6 @@ import org.sopt.makers.operation.dto.lecture.AttendanceResponseDTO;
 import org.sopt.makers.operation.dto.lecture.LectureRequestDTO;
 import org.sopt.makers.operation.dto.lecture.LectureResponseDTO;
 import org.sopt.makers.operation.dto.lecture.LecturesResponseDTO;
-import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.service.AdminService;
 import org.sopt.makers.operation.service.LectureService;
 import org.springframework.http.ResponseEntity;
@@ -69,17 +68,9 @@ public class LectureController {
 	}
 
 	@ApiOperation(value = "세션 상세 조회")
-	@ApiResponses({
-		@io.swagger.annotations.ApiResponse(code = 200, message = "세션 상세 조회 성공"),
-		@io.swagger.annotations.ApiResponse(code = 400, message = "필요한 값이 없음"),
-		@io.swagger.annotations.ApiResponse(code = 401, message = "유효하지 않은 토큰"),
-		@io.swagger.annotations.ApiResponse(code = 500, message = "서버 에러")
-	})
 	@GetMapping("/{lectureId}")
-	public ResponseEntity<ApiResponse> getLecture(@PathVariable("lectureId") Long lectureId,
-		@RequestParam(required = false, name = "part") Part part, Principal principal) {
-		adminService.confirmAdmin(Long.valueOf(principal.getName()));
-		LectureResponseDTO response = lectureService.getLecture(lectureId, part);
+	public ResponseEntity<ApiResponse> getLecture(@PathVariable Long lectureId) {
+		LectureResponseDTO response = lectureService.getLecture(lectureId);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_LECTURE.getMessage(), response));
 	}
 

--- a/src/main/java/org/sopt/makers/operation/dto/attendance/MemberResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/attendance/MemberResponseDTO.java
@@ -1,0 +1,51 @@
+package org.sopt.makers.operation.dto.attendance;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.sopt.makers.operation.entity.Attendance;
+import org.sopt.makers.operation.entity.AttendanceStatus;
+import org.sopt.makers.operation.entity.Member;
+import org.sopt.makers.operation.entity.SubAttendance;
+
+public record MemberResponseDTO(
+	Long attendanceId,
+	MemberVO member,
+	List<SubAttendanceVO> attendances,
+	float updatedScore) {
+
+	public static MemberResponseDTO of(Attendance attendance, float updatedScore) {
+		return new MemberResponseDTO(
+			attendance.getId(),
+			MemberVO.of(attendance.getMember()),
+			attendance.getSubAttendances().stream().map(SubAttendanceVO::of).toList(),
+			updatedScore
+		);
+	}
+}
+
+record MemberVO(Long memberId, String name, String university) {
+	static MemberVO of(Member member) {
+		return new MemberVO(
+			member.getId(),
+			member.getName(),
+			member.getUniversity()
+		);
+	}
+}
+
+record SubAttendanceVO(Long subAttendanceId, int round, AttendanceStatus status, String updateAt) {
+	static SubAttendanceVO of(SubAttendance subAttendance) {
+		return new SubAttendanceVO(
+			subAttendance.getId(),
+			subAttendance.getSubLecture().getRound(),
+			subAttendance.getStatus(),
+			transfer(subAttendance.getLastModifiedDate())
+		);
+	}
+
+	private static String transfer(LocalDateTime time) {
+		return time.format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm"));
+	}
+}

--- a/src/main/java/org/sopt/makers/operation/dto/lecture/AttendanceRequestDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/lecture/AttendanceRequestDTO.java
@@ -1,4 +1,8 @@
 package org.sopt.makers.operation.dto.lecture;
 
-public record AttendanceRequestDTO(Long lectureId, int round) {
+public record AttendanceRequestDTO(
+	Long lectureId,
+	int round,
+	String code
+) {
 }

--- a/src/main/java/org/sopt/makers/operation/dto/lecture/LectureResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/lecture/LectureResponseDTO.java
@@ -3,13 +3,10 @@ package org.sopt.makers.operation.dto.lecture;
 import static org.sopt.makers.operation.entity.AttendanceStatus.*;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.sopt.makers.operation.entity.Attendance;
-import org.sopt.makers.operation.entity.AttendanceStatus;
 import org.sopt.makers.operation.entity.Part;
-import org.sopt.makers.operation.entity.SubAttendance;
 import org.sopt.makers.operation.entity.SubLecture;
 import org.sopt.makers.operation.entity.lecture.Attribute;
 import org.sopt.makers.operation.entity.lecture.Lecture;
@@ -20,16 +17,17 @@ public record LectureResponseDTO(
 	Part part,
 	Attribute attribute,
 	List<SubLectureVO> subLectures,
-	List<MemberVO> members
+	AttendanceInfo result
+
 ) {
-	public static LectureResponseDTO of(Lecture lecture, List<Attendance> attendances) {
+	public static LectureResponseDTO of(Lecture lecture) {
 		return new LectureResponseDTO(
 			lecture.getName(),
 			lecture.getGeneration(),
 			lecture.getPart(),
 			lecture.getAttribute(),
 			lecture.getSubLectures().stream().map(SubLectureVO::of).toList(),
-			attendances.stream().map(MemberVO::of).toList()
+			AttendanceInfo.of(lecture, lecture.getAttendances())
 		);
 	}
 }
@@ -37,78 +35,34 @@ public record LectureResponseDTO(
 record SubLectureVO(
 	Long subLectureId,
 	int round,
-	String startAt
+	String startAt,
+	String code
 ) {
 	static SubLectureVO of(SubLecture subLecture) {
 		String startAt = subLecture.getStartAt() != null ? subLecture.getStartAt().toString() : null;
-		return new SubLectureVO(subLecture.getId(), subLecture.getRound(), startAt);
+		return new SubLectureVO(subLecture.getId(), subLecture.getRound(), startAt, subLecture.getCode());
 	}
 }
 
-record MemberVO(
-	String name,
-	String university,
-	List<MemberAttendanceVO> attendances,
-	float score
+record AttendanceInfo(
+	long attendance,
+	long tardy,
+	long absent,
+	long unknown
 ) {
-	static MemberVO of(Attendance attendance) {
-		List<MemberAttendanceVO> attendances = attendance.getSubAttendances()
-			.stream().map(MemberAttendanceVO::of)
-			.toList();
+	static AttendanceInfo of(Lecture lecture, List<Attendance> attendances) {
+		long count = attendances.stream().filter(info -> info.getStatus().equals(ABSENT)).count();
+		long[] result = getCount(count, lecture.getEndDate());
 
-		float score = 0;
-		if (attendance.getLecture().getEndDate().isBefore(LocalDateTime.now())) {
-			score = getScore(attendance.getLecture().getAttribute(), attendances);
-		}
-
-		return new MemberVO(
-			attendance.getMember().getName(),
-			attendance.getMember().getUniversity(),
-			attendances,
-			score
+		return new AttendanceInfo(
+			attendances.stream().filter(info -> info.getStatus().equals(ATTENDANCE)).count(),
+			attendances.stream().filter(info -> info.getStatus().equals(TARDY)).count(),
+			result[0],
+			result[1]
 		);
 	}
 
-	private static float getScore(Attribute attribute, List<MemberAttendanceVO> attendances) {
-		return switch (attribute) {
-			case SEMINAR -> getResultInSeminar32(attendances.get(0).status(), attendances.get(1).status());
-			case EVENT -> getResultInEvent32(attendances.get(1).status());
-			case ETC -> 0;
-		};
+	private static long[] getCount(long count, LocalDateTime endDate) {
+		return endDate.isBefore(LocalDateTime.now()) ? new long[] {count, 0} : new long[] {0, count};
 	}
-
-	private static float getResultInSeminar32 (AttendanceStatus first, AttendanceStatus second) {
-		if (first.equals(ATTENDANCE) && second.equals(ATTENDANCE)) {
-			return 0; // 출석
-		} else if (first.equals(ABSENT) && second.equals(ATTENDANCE)) {
-			return -0.5f; // 지각
-		}
-		return -1;
-	}
-
-	private static float getResultInEvent32(AttendanceStatus second) {
-		return second.equals(ATTENDANCE) ? 0.5f : 0;
-	}
-}
-
-record MemberAttendanceVO(
-	Long subAttendanceId,
-	int round,
-	AttendanceStatus status,
-	String date) {
-	static MemberAttendanceVO of(SubAttendance subAttendance) {
-		return new MemberAttendanceVO(
-			subAttendance.getId(),
-			subAttendance.getSubLecture().getRound(),
-			subAttendance.getStatus(),
-			subAttendance.getSubLecture().getStartAt() != null
-				? convertDateToString(subAttendance.getLastModifiedDate())
-				: null
-		);
-	}
-
-	private static String convertDateToString(LocalDateTime dateTime) {
-		return dateTime.format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm"));
-	}
-
 }

--- a/src/main/java/org/sopt/makers/operation/dto/lecture/LectureResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/lecture/LectureResponseDTO.java
@@ -12,6 +12,7 @@ import org.sopt.makers.operation.entity.lecture.Attribute;
 import org.sopt.makers.operation.entity.lecture.Lecture;
 
 public record LectureResponseDTO(
+	Long lectureId,
 	String name,
 	int generation,
 	Part part,
@@ -22,6 +23,7 @@ public record LectureResponseDTO(
 ) {
 	public static LectureResponseDTO of(Lecture lecture) {
 		return new LectureResponseDTO(
+			lecture.getId(), 
 			lecture.getName(),
 			lecture.getGeneration(),
 			lecture.getPart(),

--- a/src/main/java/org/sopt/makers/operation/entity/SubLecture.java
+++ b/src/main/java/org/sopt/makers/operation/entity/SubLecture.java
@@ -42,8 +42,6 @@ public class SubLecture {
 	@OneToMany(mappedBy = "subLecture")
 	private final List<SubAttendance> subAttendances = new ArrayList<>();
 
-	private Long code;
-
 	public SubLecture(Lecture lecture, int round) {
 		setLecture(lecture);
 		this.round = round;

--- a/src/main/java/org/sopt/makers/operation/entity/SubLecture.java
+++ b/src/main/java/org/sopt/makers/operation/entity/SubLecture.java
@@ -38,6 +38,8 @@ public class SubLecture {
 
 	private LocalDateTime startAt;
 
+	private String code;
+
 	@OneToMany(mappedBy = "subLecture")
 	private final List<SubAttendance> subAttendances = new ArrayList<>();
 
@@ -46,8 +48,9 @@ public class SubLecture {
 		this.round = round;
 	}
 
-	public void startAttendance() {
+	public void startAttendance(String code) {
 		this.startAt = LocalDateTime.now();
+		this.code = code;
 	}
 
 	private void setLecture(Lecture lecture) {

--- a/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceCustomRepository.java
+++ b/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceCustomRepository.java
@@ -5,11 +5,12 @@ import java.util.List;
 import org.sopt.makers.operation.entity.Attendance;
 import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.entity.lecture.Lecture;
+import org.springframework.data.domain.Pageable;
 
 public interface AttendanceCustomRepository {
 	Long countAttendance(Lecture lecture);
 	Long countAbsent(Lecture lecture);
 	Long countTardy(Lecture lecture);
-	List<Attendance> getAttendanceByPart(Lecture lecture, Part part);
 	List<Attendance> findAttendanceByMemberId(Long memberId);
+	List<Attendance> findLectureAttendances(Lecture lecture, Part part, Pageable pageable);
 }

--- a/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceRepositoryImpl.java
@@ -61,19 +61,6 @@ public class AttendanceRepositoryImpl implements AttendanceCustomRepository {
 	}
 
 	@Override
-	public List<Attendance> getAttendanceByPart(Lecture lecture, Part part) {
-		return queryFactory
-			.select(attendance)
-			.from(attendance)
-			.join(attendance.member, member)
-			.where(
-				attendance.lecture.eq(lecture),
-				partEq(part)
-			)
-			.fetch();
-	}
-
-	@Override
 	public List<Attendance> findAttendanceByMemberId(Long memberId) {
 		return queryFactory
 			.select(attendance)
@@ -86,7 +73,7 @@ public class AttendanceRepositoryImpl implements AttendanceCustomRepository {
 	}
 
 	@Override
-	public List<Attendance> findMemberAttendances(Lecture lecture, Part part, Pageable pageable) {
+	public List<Attendance> findLectureAttendances(Lecture lecture, Part part, Pageable pageable) {
 		return queryFactory
 			.select(attendance)
 			.from(attendance)

--- a/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceRepositoryImpl.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.operation.repository.attendance;
 
-import static java.util.Objects.*;
 import static org.sopt.makers.operation.entity.Part.*;
 import static org.sopt.makers.operation.entity.QAttendance.*;
 import static org.sopt.makers.operation.entity.QMember.*;
@@ -11,6 +10,7 @@ import org.sopt.makers.operation.entity.Attendance;
 import org.sopt.makers.operation.entity.AttendanceStatus;
 import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.entity.lecture.Lecture;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -82,6 +82,22 @@ public class AttendanceRepositoryImpl implements AttendanceCustomRepository {
 				attendance.member.id.eq(memberId)
 			)
 			.orderBy(attendance.lecture.startDate.desc())
+			.fetch();
+	}
+
+	@Override
+	public List<Attendance> findMemberAttendances(Lecture lecture, Part part, Pageable pageable) {
+		return queryFactory
+			.select(attendance)
+			.from(attendance)
+			.leftJoin(attendance.member, member)
+			.where(
+				attendance.lecture.eq(lecture),
+				partEq(part)
+			)
+			.orderBy(member.name.asc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
 			.fetch();
 	}
 

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceService.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceService.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.operation.service;
 
-<<<<<<< HEAD
 import java.util.List;
 
 import org.sopt.makers.operation.dto.attendance.AttendanceMemberResponseDTO;
@@ -9,17 +8,12 @@ import org.sopt.makers.operation.dto.attendance.AttendanceResponseDTO;
 import org.sopt.makers.operation.dto.attendance.MemberResponseDTO;
 import org.sopt.makers.operation.entity.Part;
 import org.springframework.data.domain.Pageable;
-=======
 import org.sopt.makers.operation.dto.attendance.*;
->>>>>>> develop
 
 public interface AttendanceService {
 	AttendanceResponseDTO updateAttendanceStatus(AttendanceRequestDTO requestDTO);
 	AttendanceMemberResponseDTO getMemberAttendance(Long memberId);
 	float updateMemberScore(Long memberId);
-<<<<<<< HEAD
 	List<MemberResponseDTO> getMemberAttendances(Long lectureId, Part part, Pageable pageable);
-=======
 	AttendResponseDTO attend(Long memberId, AttendRequestDTO requestDTO);
->>>>>>> develop
 }

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceService.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceService.java
@@ -1,11 +1,17 @@
 package org.sopt.makers.operation.service;
 
+import java.util.List;
+
 import org.sopt.makers.operation.dto.attendance.AttendanceMemberResponseDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceRequestDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceResponseDTO;
+import org.sopt.makers.operation.dto.attendance.MemberResponseDTO;
+import org.sopt.makers.operation.entity.Part;
+import org.springframework.data.domain.Pageable;
 
 public interface AttendanceService {
 	AttendanceResponseDTO updateAttendanceStatus(AttendanceRequestDTO requestDTO);
 	AttendanceMemberResponseDTO getMemberAttendance(Long memberId);
 	float updateMemberScore(Long memberId);
+	List<MemberResponseDTO> getMemberAttendances(Long lectureId, Part part, Pageable pageable);
 }

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
@@ -8,34 +8,28 @@ import java.util.List;
 
 import javax.persistence.EntityNotFoundException;
 
-<<<<<<< HEAD
 import org.sopt.makers.operation.dto.attendance.AttendanceMemberResponseDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceRequestDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceResponseDTO;
 import org.sopt.makers.operation.dto.attendance.MemberResponseDTO;
-=======
 import lombok.val;
 import org.sopt.makers.operation.dto.attendance.*;
->>>>>>> develop
 import org.sopt.makers.operation.entity.Attendance;
 import org.sopt.makers.operation.entity.AttendanceStatus;
 import org.sopt.makers.operation.entity.Member;
 import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.entity.SubAttendance;
 import org.sopt.makers.operation.entity.lecture.Attribute;
-<<<<<<< HEAD
 import org.sopt.makers.operation.entity.lecture.Lecture;
 import org.sopt.makers.operation.exception.LectureException;
 import org.sopt.makers.operation.repository.SubAttendanceRepository;
 import org.sopt.makers.operation.repository.attendance.AttendanceRepository;
 import org.sopt.makers.operation.repository.lecture.LectureRepository;
-=======
 import org.sopt.makers.operation.exception.LectureException;
 import org.sopt.makers.operation.exception.SubLectureException;
 import org.sopt.makers.operation.repository.SubAttendanceRepository;
 import org.sopt.makers.operation.repository.attendance.AttendanceRepository;
 import org.sopt.makers.operation.repository.lecture.SubLectureRepository;
->>>>>>> develop
 import org.sopt.makers.operation.repository.member.MemberRepository;
 import org.sopt.makers.operation.util.Generation32;
 import org.springframework.data.domain.Pageable;
@@ -54,11 +48,8 @@ public class AttendanceServiceImpl implements AttendanceService {
 
 	private final SubAttendanceRepository subAttendanceRepository;
 	private final MemberRepository memberRepository;
-<<<<<<< HEAD
 	private final LectureRepository lectureRepository;
-=======
 	private final SubLectureRepository subLectureRepository;
->>>>>>> develop
 	private final AttendanceRepository attendanceRepository;
 	private final Generation32 sopt32;
 
@@ -90,7 +81,6 @@ public class AttendanceServiceImpl implements AttendanceService {
 	}
 
 	@Override
-<<<<<<< HEAD
 	public List<MemberResponseDTO> getMemberAttendances(Long lectureId, Part part, Pageable pageable) {
 		Lecture lecture = findLecture(lectureId);
 		List<Attendance> attendances = attendanceRepository.findLectureAttendances(lecture, part, pageable);
@@ -100,7 +90,8 @@ public class AttendanceServiceImpl implements AttendanceService {
 				sopt32.getUpdateScore(lecture.getAttribute(), attendance.getStatus())
 			)
 		).toList();
-=======
+	}
+
 	@Transactional
 	public AttendResponseDTO attend(Long memberId, AttendRequestDTO requestDTO) {
 		val now = LocalDateTime.now();
@@ -130,7 +121,6 @@ public class AttendanceServiceImpl implements AttendanceService {
 		}
 
 		return AttendResponseDTO.of(subLecture.getId());
->>>>>>> develop
 	}
 
 	private float getUpdateScore(Attendance attendance, Attribute attribute) {

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
@@ -4,18 +4,27 @@ import static org.sopt.makers.operation.common.ExceptionMessage.*;
 import static org.sopt.makers.operation.entity.AttendanceStatus.*;
 import static org.sopt.makers.operation.entity.lecture.Attribute.*;
 
+import java.util.List;
+
 import javax.persistence.EntityNotFoundException;
 
 import org.sopt.makers.operation.dto.attendance.AttendanceMemberResponseDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceRequestDTO;
 import org.sopt.makers.operation.dto.attendance.AttendanceResponseDTO;
+import org.sopt.makers.operation.dto.attendance.MemberResponseDTO;
 import org.sopt.makers.operation.entity.Attendance;
 import org.sopt.makers.operation.entity.Member;
+import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.entity.SubAttendance;
 import org.sopt.makers.operation.entity.lecture.Attribute;
+import org.sopt.makers.operation.entity.lecture.Lecture;
+import org.sopt.makers.operation.exception.LectureException;
 import org.sopt.makers.operation.repository.SubAttendanceRepository;
+import org.sopt.makers.operation.repository.attendance.AttendanceRepository;
+import org.sopt.makers.operation.repository.lecture.LectureRepository;
 import org.sopt.makers.operation.repository.member.MemberRepository;
 import org.sopt.makers.operation.util.Generation32;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +37,8 @@ public class AttendanceServiceImpl implements AttendanceService {
 
 	private final SubAttendanceRepository subAttendanceRepository;
 	private final MemberRepository memberRepository;
+	private final LectureRepository lectureRepository;
+	private final AttendanceRepository attendanceRepository;
 	private final Generation32 sopt32;
 
 	@Override
@@ -57,6 +68,18 @@ public class AttendanceServiceImpl implements AttendanceService {
 		return member.getScore();
 	}
 
+	@Override
+	public List<MemberResponseDTO> getMemberAttendances(Long lectureId, Part part, Pageable pageable) {
+		Lecture lecture = findLecture(lectureId);
+		List<Attendance> attendances = attendanceRepository.findLectureAttendances(lecture, part, pageable);
+		return attendances.stream().map(attendance ->
+			MemberResponseDTO.of(
+				attendance,
+				sopt32.getUpdateScore(lecture.getAttribute(), attendance.getStatus())
+			)
+		).toList();
+	}
+
 	private float getUpdateScore(Attendance attendance, Attribute attribute) {
 		if (attribute.equals(SEMINAR)) {
 			if (attendance.getStatus().equals(TARDY)) {
@@ -80,5 +103,10 @@ public class AttendanceServiceImpl implements AttendanceService {
 	private SubAttendance findSubAttendance(Long id) {
 		return subAttendanceRepository.findById(id)
 			.orElseThrow(() -> new EntityNotFoundException(INVALID_ATTENDANCE.getName()));
+	}
+
+	private Lecture findLecture(Long id) {
+		return lectureRepository.findById(id)
+			.orElseThrow(() -> new LectureException(INVALID_LECTURE.getName()));
 	}
 }

--- a/src/main/java/org/sopt/makers/operation/service/LectureService.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureService.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.operation.service;
 
-import org.sopt.makers.operation.dto.attendance.AttendanceTotalResponseDTO;
 import org.sopt.makers.operation.dto.lecture.LectureGetResponseDTO;
 import org.sopt.makers.operation.dto.lecture.AttendanceRequestDTO;
 import org.sopt.makers.operation.dto.lecture.AttendanceResponseDTO;
@@ -8,14 +7,12 @@ import org.sopt.makers.operation.dto.lecture.LectureRequestDTO;
 import org.sopt.makers.operation.dto.lecture.LectureSearchCondition;
 import org.sopt.makers.operation.dto.lecture.LectureResponseDTO;
 import org.sopt.makers.operation.dto.lecture.LecturesResponseDTO;
-import org.sopt.makers.operation.entity.Member;
-import org.sopt.makers.operation.entity.Part;
 
 public interface LectureService {
 	Long createLecture(LectureRequestDTO requestDTO);
 	LectureGetResponseDTO getCurrentLecture(LectureSearchCondition lectureSearchCondition);
 	LecturesResponseDTO getLecturesByGeneration(int generation);
-	LectureResponseDTO getLecture(Long lectureId, Part part);
+	LectureResponseDTO getLecture(Long lectureId);
 	AttendanceResponseDTO startAttendance(AttendanceRequestDTO requestDTO);
 	void updateMembersScore(Long lectureId);
 

--- a/src/main/java/org/sopt/makers/operation/service/LectureService.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureService.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.operation.service;
 
-<<<<<<< HEAD
 import org.sopt.makers.operation.dto.lecture.LectureGetResponseDTO;
 import org.sopt.makers.operation.dto.lecture.AttendanceRequestDTO;
 import org.sopt.makers.operation.dto.lecture.AttendanceResponseDTO;
@@ -8,10 +7,7 @@ import org.sopt.makers.operation.dto.lecture.LectureRequestDTO;
 import org.sopt.makers.operation.dto.lecture.LectureSearchCondition;
 import org.sopt.makers.operation.dto.lecture.LectureResponseDTO;
 import org.sopt.makers.operation.dto.lecture.LecturesResponseDTO;
-=======
 import org.sopt.makers.operation.dto.lecture.*;
-import org.sopt.makers.operation.entity.Part;
->>>>>>> develop
 
 public interface LectureService {
 	Long createLecture(LectureRequestDTO requestDTO);

--- a/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
@@ -113,10 +113,9 @@ public class LectureServiceImpl implements LectureService {
 	}
 
 	@Override
-	public LectureResponseDTO getLecture(Long lectureId, Part part) {
+	public LectureResponseDTO getLecture(Long lectureId) {
 		Lecture lecture = findLecture(lectureId);
-		List<Attendance> attendances = attendanceRepository.getAttendanceByPart(lecture, part);
-		return LectureResponseDTO.of(lecture, attendances);
+		return LectureResponseDTO.of(lecture);
 	}
 
 	@Override
@@ -128,7 +127,7 @@ public class LectureServiceImpl implements LectureService {
 			if (subLecture.getRound() < requestDTO.round() && subLecture.getStartAt() == null) {
 				throw new IllegalStateException(NOT_STARTED_PRE_ATTENDANCE.getName());
 			} else if (subLecture.getRound() == requestDTO.round()) {
-				subLecture.startAttendance();
+				subLecture.startAttendance(requestDTO.code());
 				return new AttendanceResponseDTO(lecture.getId(), subLecture.getId());
 			}
 		}

--- a/src/main/java/org/sopt/makers/operation/util/Generation32.java
+++ b/src/main/java/org/sopt/makers/operation/util/Generation32.java
@@ -12,6 +12,29 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class Generation32 {
 
+	public float getUpdateScore(Attribute attribute, AttendanceStatus status) {
+		return switch (attribute) {
+			case SEMINAR -> getUpdateScoreInSeminar(status);
+			case EVENT -> getUpdateScoreInEvent(status);
+			default -> 0;
+		};
+	}
+
+	private float getUpdateScoreInSeminar(AttendanceStatus status) {
+		return switch (status) {
+			case TARDY -> -0.5f;
+			case ABSENT -> -1f;
+			default -> 0f;
+		};
+	}
+
+	private float getUpdateScoreInEvent(AttendanceStatus status) {
+		if (status.equals(ATTENDANCE)) {
+			return 0.5f;
+		}
+		return 0;
+	}
+
 	public AttendanceStatus getAttendanceStatus(Attribute attribute, List<SubAttendance> subAttendances) {
 		int firstRound = subAttendances.get(0).getSubLecture().getRound() == 1 ? 0 : 1;
 		SubAttendance first = subAttendances.get(firstRound);


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
closed #84 

## Work Description ✏️
- 세션 상세 조회 기능 분리: part 쿼리를 삭제 (출석 리스트에서 반영 필요)
- SubLecture 출석 코드 추가
- 세션 출석 정보 리스트 조회 기능 추가: 페이징 처리 (page: 페이지 번호, size: 페이지 당 데이터 개수)
- 토큰 유효성은 filter 에서 확인해주는 것으로 인지하고 confirmAdmin의 필요성에 대해 의구심을 가지게 되면서 삭제했습니다. 의논해보면 좋을 것 같아요!
- ApiResponses 어노테이션 코드가 차지하는 공간이 커서 코드가 복잡해보이더라구요. 우선 빼봤는데 이전 거와 비교했을 때 들고갈 지 두고갈 지도 의논해보면 좋을 것 같아요!

## PR Point 📸
- 세션 상세 조회: lecture, subLecture, Attendance 총 3번의 쿼리가 발생하는데 괜찮겠죠 ..!?
- 출석 정보 조회는 쿼리 최적화가 쉽지 않네요.. 😭 일단 올려놓고 계속 생각해보겟슴다 ㅠㅅㅠ