### PR TITLE
[REFACT] 로그인, 리프레시 service 작동 방식, 쿠키 모듈화

### DIFF
--- a/src/main/java/org/sopt/makers/operation/controller/AdminController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/AdminController.java
@@ -38,11 +38,9 @@ public class AdminController {
     @ApiOperation(value = "로그인")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse> login(@RequestBody LoginRequestDTO userLoginRequestDTO) {
-        //TODO: login + refresh 토큰 코드 통일화 {response: "...", token: "..."}
         val response = authService.login(userLoginRequestDTO);
-        val refreshToken = authService.getRefreshToken(response.id());
 
-        val cookie = ResponseCookie.from("refreshToken", refreshToken)
+        val cookie = ResponseCookie.from("refreshToken", response.refreshToken())
             .httpOnly(true)
             .maxAge(Duration.ofDays(14))
             .secure(true)
@@ -54,7 +52,7 @@ public class AdminController {
 
         return ResponseEntity.status(OK)
             .headers(headers)
-            .body(ApiResponse.success(SUCCESS_LOGIN_UP.getMessage(), response));
+            .body(ApiResponse.success(SUCCESS_LOGIN_UP.getMessage(), response.loginResponseVO()));
     }
 
     @ApiOperation(value = "토큰 재발급")

--- a/src/main/java/org/sopt/makers/operation/controller/AdminController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/AdminController.java
@@ -57,17 +57,12 @@ public class AdminController {
 
     @ApiOperation(value = "토큰 재발급")
     @PatchMapping("/refresh")
-    public ResponseEntity<ApiResponse> refresh(@CookieValue(name = "refreshToken") String refreshToken) {
-        //TODO: jwtTokenProvider.getId 내부에서 validateRefreshToken 수행하고 adminId 반환 방식 제안
+    public ResponseEntity<ApiResponse> refresh(@CookieValue String refreshToken) {
         val adminId = jwtTokenProvider.getId(refreshToken, JwtTokenType.REFRESH_TOKEN);
-        authService.validateRefreshToken(adminId, refreshToken);
 
-        val adminAuthentication = new AdminAuthentication(adminId, null, null);
-        val newRefreshToken = jwtTokenProvider.generateRefreshToken(adminAuthentication);
-        val newAccessToken = jwtTokenProvider.generateAccessToken(adminAuthentication);
-        authService.refresh(adminId, newRefreshToken);
+        val response = authService.refresh(adminId, refreshToken);
 
-        val cookie = ResponseCookie.from("refreshToken", newRefreshToken)
+        val cookie = ResponseCookie.from("refreshToken", response.refreshToken())
             .httpOnly(true)
             .maxAge(Duration.ofDays(14))
             .secure(true)
@@ -78,6 +73,6 @@ public class AdminController {
         headers.add(SET_COOKIE, cookie.toString());
 
         return ResponseEntity.status(OK).headers(headers)
-            .body(ApiResponse.success(SUCCESS_GET_REFRESH_TOKEN.getMessage(), newAccessToken));
+            .body(ApiResponse.success(SUCCESS_GET_REFRESH_TOKEN.getMessage(), response.accessToken()));
     }
 }

--- a/src/main/java/org/sopt/makers/operation/controller/AdminController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/AdminController.java
@@ -1,7 +1,6 @@
 package org.sopt.makers.operation.controller;
 
 import static org.sopt.makers.operation.common.ResponseMessage.*;
-import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpStatus.*;
 
 import io.swagger.annotations.ApiOperation;
@@ -10,23 +9,16 @@ import lombok.val;
 
 import org.sopt.makers.operation.common.ApiResponse;
 import org.sopt.makers.operation.dto.admin.*;
-import org.sopt.makers.operation.security.jwt.JwtTokenProvider;
-import org.sopt.makers.operation.security.jwt.JwtTokenType;
 import org.sopt.makers.operation.service.AdminServiceImpl;
 import org.sopt.makers.operation.util.Cookie;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.Duration;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 public class AdminController {
     private final AdminServiceImpl authService;
-    private final JwtTokenProvider jwtTokenProvider;
     private final Cookie cookie;
 
     @ApiOperation(value = "회원가입")
@@ -50,8 +42,7 @@ public class AdminController {
     @ApiOperation(value = "토큰 재발급")
     @PatchMapping("/refresh")
     public ResponseEntity<ApiResponse> refresh(@CookieValue String refreshToken) {
-        val adminId = jwtTokenProvider.getId(refreshToken, JwtTokenType.REFRESH_TOKEN);
-        val response = authService.refresh(adminId, refreshToken);
+        val response = authService.refresh(refreshToken);
         val headers = cookie.setRefreshToken(response.refreshToken());
 
         return ResponseEntity.status(OK).headers(headers)

--- a/src/main/java/org/sopt/makers/operation/dto/admin/LoginResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/admin/LoginResponseDTO.java
@@ -1,4 +1,20 @@
 package org.sopt.makers.operation.dto.admin;
 
-public record LoginResponseDTO(Long id, String name, String accessToken) {
+import org.sopt.makers.operation.entity.Admin;
+
+public record LoginResponseDTO(LoginResponseVO loginResponseVO, String refreshToken) {
+    public static LoginResponseDTO of(Admin admin, String accessToken, String refreshToken) {
+        return new LoginResponseDTO(
+                LoginResponseVO.of(admin.getId(), admin.getName(), accessToken),
+                refreshToken
+        );
+    }
+}
+
+record LoginResponseVO(Long id, String name, String accessToken) {
+    public static LoginResponseVO of(Long id, String name, String accessToken) {
+        return new LoginResponseVO(
+                id, name, accessToken
+        );
+    }
 }

--- a/src/main/java/org/sopt/makers/operation/dto/admin/RefreshResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/admin/RefreshResponseDTO.java
@@ -1,9 +1,12 @@
 package org.sopt.makers.operation.dto.admin;
 
-public record RefreshResponseDTO(String accessToken) {
-    public static RefreshResponseDTO of(String accessToken) {
+import lombok.Getter;
+
+public record RefreshResponseDTO(String accessToken, String refreshToken) {
+    public static RefreshResponseDTO of(String accessToken, String refreshToken) {
         return new RefreshResponseDTO(
-                accessToken
+                accessToken,
+                refreshToken
         );
     }
 }

--- a/src/main/java/org/sopt/makers/operation/service/AdminService.java
+++ b/src/main/java/org/sopt/makers/operation/service/AdminService.java
@@ -6,8 +6,6 @@ import org.sopt.makers.operation.entity.Admin;
 public interface AdminService {
     SignUpResponseDTO signUp(SignUpRequestDTO signUpRequestDTO);
     LoginResponseDTO login(LoginRequestDTO userLoginRequestDTO);
-    void confirmAdmin(Long adminId);
-    String getRefreshToken(Long adminId);
     void validateRefreshToken(Long adminId, String requestRefreshToken);
-    RefreshResponseDTO refresh(Long adminId, String refreshToken);
+    RefreshResponseDTO refresh(String refreshToken);
 }

--- a/src/main/java/org/sopt/makers/operation/service/AdminService.java
+++ b/src/main/java/org/sopt/makers/operation/service/AdminService.java
@@ -9,5 +9,5 @@ public interface AdminService {
     void confirmAdmin(Long adminId);
     String getRefreshToken(Long adminId);
     void validateRefreshToken(Long adminId, String requestRefreshToken);
-    void refresh(Long adminId, String newRefreshToken);
+    RefreshResponseDTO refresh(Long adminId, String refreshToken);
 }

--- a/src/main/java/org/sopt/makers/operation/service/AdminServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AdminServiceImpl.java
@@ -14,6 +14,7 @@ import org.sopt.makers.operation.exception.AdminFailureException;
 import org.sopt.makers.operation.repository.AdminRepository;
 import org.sopt.makers.operation.security.jwt.AdminAuthentication;
 import org.sopt.makers.operation.security.jwt.JwtTokenProvider;
+import org.sopt.makers.operation.security.jwt.JwtTokenType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,16 +64,6 @@ public class AdminServiceImpl implements AdminService {
     }
 
     @Override
-    public void confirmAdmin(Long adminId) {
-        this.findById(adminId);
-    }
-
-    @Override
-    public String getRefreshToken(Long adminId) {
-        return this.findById(adminId).getRefreshToken();
-    }
-
-    @Override
     public void validateRefreshToken(Long adminId, String requestRefreshToken) {
         val admin = this.findById(adminId);
         val refreshToken = admin.getRefreshToken();
@@ -82,7 +73,9 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     @Transactional
-    public RefreshResponseDTO refresh(Long adminId, String refreshToken) {
+    public RefreshResponseDTO refresh(String refreshToken) {
+        val adminId = jwtTokenProvider.getId(refreshToken, JwtTokenType.REFRESH_TOKEN);
+
         validateRefreshToken(adminId, refreshToken);
 
         val adminAuthentication = new AdminAuthentication(adminId, null, null);

--- a/src/main/java/org/sopt/makers/operation/service/AdminServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AdminServiceImpl.java
@@ -82,10 +82,17 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     @Transactional
-    public void refresh(Long adminId, String newRefreshToken) {
-        val admin = this.findById(adminId);
+    public RefreshResponseDTO refresh(Long adminId, String refreshToken) {
+        validateRefreshToken(adminId, refreshToken);
+
+        val adminAuthentication = new AdminAuthentication(adminId, null, null);
+        val newAccessToken = jwtTokenProvider.generateAccessToken(adminAuthentication);
+        val newRefreshToken = jwtTokenProvider.generateRefreshToken(adminAuthentication);
+        val admin = findById(adminId);
 
         admin.updateRefreshToken(newRefreshToken);
+
+        return RefreshResponseDTO.of(newAccessToken, newRefreshToken);
     }
 
     private Admin findById(Long adminId) {

--- a/src/main/java/org/sopt/makers/operation/service/AdminServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AdminServiceImpl.java
@@ -59,7 +59,7 @@ public class AdminServiceImpl implements AdminService {
 
         admin.updateRefreshToken(jwtTokenProvider.generateRefreshToken(authentication));
 
-        return new LoginResponseDTO(admin.getId(), admin.getName(), jwtTokenProvider.generateAccessToken(authentication));
+        return LoginResponseDTO.of(admin, jwtTokenProvider.generateAccessToken(authentication), admin.getRefreshToken());
     }
 
     @Override

--- a/src/main/java/org/sopt/makers/operation/util/Cookie.java
+++ b/src/main/java/org/sopt/makers/operation/util/Cookie.java
@@ -1,0 +1,27 @@
+package org.sopt.makers.operation.util;
+
+import lombok.val;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseCookie;
+
+import org.springframework.http.HttpHeaders;
+import java.time.Duration;
+
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
+@Configuration
+public class Cookie {
+    public HttpHeaders setRefreshToken(String refreshToken) {
+        val cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .maxAge(Duration.ofDays(14))
+                .secure(true)
+                .path("/")
+                .build();
+
+        val headers = new org.springframework.http.HttpHeaders();
+        headers.add(SET_COOKIE, cookie.toString());
+
+        return headers;
+    }
+}


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #88

## Work Description ✏️
- 로그인에서 리프레시 토큰을 업데이트할때 service에서 한꺼번에 하도록 변경
- 리프레시 할때 refresh 토큰 유효성 검증을 service에서 하도록 변경
- 쿠키를 controller에서 중복된 코드로 사용하는게 아닌 모듈을 사용하도록 변경

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 컨트롤러 사이즈 괜찮은지 궁금합니다