### PR TITLE
[FIX] 출석 종료 기능 수정: 설명 워딩 추가, 예외 처리 추가

### DIFF
--- a/src/main/java/org/sopt/makers/operation/common/ExceptionMessage.java
+++ b/src/main/java/org/sopt/makers/operation/common/ExceptionMessage.java
@@ -17,7 +17,8 @@ public enum ExceptionMessage {
 	NOT_STARTED_NTH_ATTENDANCE("차 출석 시작 전입니다."),
 	ENDED_ATTENDANCE("차 출석이 이미 종료되었습니다."),
 	INVALID_COUNT_SESSION("세션의 개수가 올바르지 않습니다."),
-	INVALID_CODE("코드가 일치하지 않아요!");
+	INVALID_CODE("코드가 일치하지 않아요!"),
+	NOT_END_TIME_YET("세션 종료 시간이 지나지 않았습니다.");
 
 
 	private final String name;

--- a/src/main/java/org/sopt/makers/operation/controller/web/LectureController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/web/LectureController.java
@@ -63,7 +63,7 @@ public class LectureController {
 			.body(ApiResponse.success(SUCCESS_START_ATTENDANCE.getMessage(), response));
 	}
 
-	@ApiOperation(value = "출석 점수 갱신 트리거")
+	@ApiOperation(value = "출석 점수 갱신 트리거 (출석 종료)")
 	@PatchMapping("/{lectureId}")
 	public ResponseEntity<ApiResponse> updateMembersScore(@PathVariable("lectureId") Long lectureId) {
 		lectureService.updateMembersScore(lectureId);

--- a/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
@@ -150,6 +150,9 @@ public class LectureServiceImpl implements LectureService {
 	public void updateMembersScore(Long lectureId) {
 		Lecture lecture = lectureRepository.findById(lectureId)
 			.orElseThrow(() -> new EntityNotFoundException(INVALID_LECTURE.getName()));
+		if (lecture.getEndDate().isAfter(LocalDateTime.now(ZoneId.of("Asia/Seoul")))) {
+			throw new IllegalStateException(NOT_END_TIME_YET.getName());
+		}
 		lecture.getAttendances().forEach(this::updateScoreIn32);
 	}
 


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
closed #99 

## Work Description ✏️
- 출석 점수 갱신 트리거가 있는데 설명(Opertaion)이 모호해서 "출석 종료" 워딩을 추가했습니다.
- 예외 처리 추가했습니다. (세션의 종료 시간이 지나기 전까지는 출석 종료가 불가합니다.)

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
