### PR TITLE
[ADD] 출석 관련 세션 상태 데이터 추가

### DIFF
--- a/src/main/java/org/sopt/makers/operation/common/ExceptionMessage.java
+++ b/src/main/java/org/sopt/makers/operation/common/ExceptionMessage.java
@@ -18,7 +18,9 @@ public enum ExceptionMessage {
 	ENDED_ATTENDANCE("차 출석이 이미 종료되었습니다."),
 	INVALID_COUNT_SESSION("세션의 개수가 올바르지 않습니다."),
 	INVALID_CODE("코드가 일치하지 않아요!"),
-	NOT_END_TIME_YET("세션 종료 시간이 지나지 않았습니다.");
+	NOT_END_TIME_YET("세션 종료 시간이 지나지 않았습니다."),
+	END_LECTURE("이미 종료된 세션입니다."),
+	NO_SUB_LECTURE_EQUAL_ROUND("해당 라운드와 일치하는 출석 세션이 없습니다.");
 
 
 	private final String name;

--- a/src/main/java/org/sopt/makers/operation/controller/web/LectureController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/web/LectureController.java
@@ -65,8 +65,8 @@ public class LectureController {
 
 	@ApiOperation(value = "출석 점수 갱신 트리거 (출석 종료)")
 	@PatchMapping("/{lectureId}")
-	public ResponseEntity<ApiResponse> updateMembersScore(@PathVariable("lectureId") Long lectureId) {
-		lectureService.updateMembersScore(lectureId);
+	public ResponseEntity<ApiResponse> finishLecture(@PathVariable("lectureId") Long lectureId) {
+		lectureService.finishLecture(lectureId);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_MEMBER_SCORE.getMessage()));
 	}
 

--- a/src/main/java/org/sopt/makers/operation/dto/lecture/LectureResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/lecture/LectureResponseDTO.java
@@ -11,6 +11,7 @@ import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.entity.SubLecture;
 import org.sopt.makers.operation.entity.lecture.Attribute;
 import org.sopt.makers.operation.entity.lecture.Lecture;
+import org.sopt.makers.operation.entity.lecture.LectureStatus;
 
 public record LectureResponseDTO(
 	Long lectureId,
@@ -19,7 +20,8 @@ public record LectureResponseDTO(
 	Part part,
 	Attribute attribute,
 	List<SubLectureVO> subLectures,
-	AttendanceInfo result
+	AttendanceInfo result,
+	LectureStatus status
 
 ) {
 	public static LectureResponseDTO of(Lecture lecture) {
@@ -30,7 +32,8 @@ public record LectureResponseDTO(
 			lecture.getPart(),
 			lecture.getAttribute(),
 			lecture.getSubLectures().stream().map(SubLectureVO::of).toList(),
-			AttendanceInfo.of(lecture, lecture.getAttendances())
+			AttendanceInfo.of(lecture, lecture.getAttendances()),
+			lecture.getLectureStatus()
 		);
 	}
 }

--- a/src/main/java/org/sopt/makers/operation/entity/SubLecture.java
+++ b/src/main/java/org/sopt/makers/operation/entity/SubLecture.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.operation.entity;
 
 import static javax.persistence.GenerationType.*;
+import static org.sopt.makers.operation.entity.lecture.LectureStatus.*;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -18,6 +19,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
 import org.sopt.makers.operation.entity.lecture.Lecture;
+import org.sopt.makers.operation.entity.lecture.LectureStatus;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -51,6 +53,15 @@ public class SubLecture {
 	public void startAttendance(String code) {
 		this.startAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 		this.code = code;
+		this.lecture.updateStatus(getUpdatedStatus());
+	}
+
+	private LectureStatus getUpdatedStatus() {
+		return switch (this.round) {
+			case 1 -> FIRST;
+			case 2 -> SECOND;
+			default -> this.lecture.getLectureStatus();
+		};
 	}
 
 	private void setLecture(Lecture lecture) {

--- a/src/main/java/org/sopt/makers/operation/entity/lecture/Lecture.java
+++ b/src/main/java/org/sopt/makers/operation/entity/lecture/Lecture.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.operation.entity.lecture;
 
 import static javax.persistence.GenerationType.*;
+import static org.sopt.makers.operation.util.Generation32.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
 import org.sopt.makers.operation.entity.Attendance;
+import org.sopt.makers.operation.entity.AttendanceStatus;
 import org.sopt.makers.operation.entity.BaseEntity;
 import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.entity.SubLecture;
@@ -38,12 +40,18 @@ public class Lecture extends BaseEntity {
 	private Part part;
 
 	private int generation;
+
 	private String place;
+
 	private LocalDateTime startDate;
+
 	private LocalDateTime endDate;
 
 	@Enumerated(EnumType.STRING)
 	private Attribute attribute;
+
+	@Enumerated(EnumType.STRING)
+	private LectureStatus lectureStatus;
 
 	@OneToMany(mappedBy = "lecture")
 	List<SubLecture> subLectures = new ArrayList<>();
@@ -61,5 +69,21 @@ public class Lecture extends BaseEntity {
 		this.startDate = startDate;
 		this.endDate = endDate;
 		this.attribute = attribute;
+		this.lectureStatus = LectureStatus.BEFORE;
+	}
+
+	public void updateStatus(LectureStatus status) {
+		this.lectureStatus = status;
+	}
+
+	public void finish() {
+		this.lectureStatus = LectureStatus.END;
+		attendances.forEach(this::updateScore);
+	}
+
+	private void updateScore(Attendance attendance) {
+		Attribute attribute = this.attribute;
+		AttendanceStatus status = attendance.getStatus();
+		attendance.getMember().updateScore(getUpdateScore(attribute, status));
 	}
 }

--- a/src/main/java/org/sopt/makers/operation/entity/lecture/LectureStatus.java
+++ b/src/main/java/org/sopt/makers/operation/entity/lecture/LectureStatus.java
@@ -1,0 +1,5 @@
+package org.sopt.makers.operation.entity.lecture;
+
+public enum LectureStatus {
+	BEFORE, FIRST, SECOND, END
+}

--- a/src/main/java/org/sopt/makers/operation/service/LectureService.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureService.java
@@ -15,7 +15,7 @@ public interface LectureService {
 	LecturesResponseDTO getLecturesByGeneration(int generation, Part part);
 	LectureResponseDTO getLecture(Long lectureId);
 	AttendanceResponseDTO startAttendance(AttendanceRequestDTO requestDTO);
-	void updateMembersScore(Long lectureId);
+	void finishLecture(Long lectureId);
 	LectureCurrentRoundResponseDTO getCurrentLectureRound(Long lectureId);
 
 }

--- a/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
@@ -193,7 +193,8 @@ public class LectureServiceImpl implements LectureService {
 	@Transactional
 	public void finishLecture(Long lectureId) {
 		val lecture = findLecture(lectureId);
-		if (lecture.getEndDate().isAfter(LocalDateTime.now(ZoneId.of("Asia/Seoul")))) {
+		val now = LocalDateTime.now(KST);
+		if (now.isBefore(lecture.getEndDate())) {
 			throw new IllegalStateException(NOT_END_TIME_YET.getName());
 		}
 		lecture.finish();

--- a/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
@@ -3,6 +3,7 @@ package org.sopt.makers.operation.service;
 import static java.util.Objects.nonNull;
 import static org.sopt.makers.operation.common.ExceptionMessage.*;
 import static org.sopt.makers.operation.entity.AttendanceStatus.*;
+import static org.sopt.makers.operation.entity.lecture.LectureStatus.*;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -171,27 +172,31 @@ public class LectureServiceImpl implements LectureService {
 	public AttendanceResponseDTO startAttendance(AttendanceRequestDTO requestDTO) {
 		Lecture lecture = findLecture(requestDTO.lectureId());
 
-		for (SubLecture subLecture : lecture.getSubLectures()) {
-			if (subLecture.getRound() < requestDTO.round() && subLecture.getStartAt() == null) {
-				throw new IllegalStateException(NOT_STARTED_PRE_ATTENDANCE.getName());
-			} else if (subLecture.getRound() == requestDTO.round()) {
-				subLecture.startAttendance(requestDTO.code());
-				return new AttendanceResponseDTO(lecture.getId(), subLecture.getId());
-			}
+		// 출석 가능 여부 유효성 체크
+		if (requestDTO.round() == 2 && lecture.getLectureStatus().equals(BEFORE)) {
+			throw new IllegalStateException(NOT_STARTED_PRE_ATTENDANCE.getName());
+		} else if (lecture.getLectureStatus().equals(END)) {
+			throw new IllegalStateException(END_LECTURE.getName());
 		}
 
-		throw new IllegalStateException(INVALID_LECTURE.getName());
+		// 출석 세션 상태 업데이트 (시작)
+		SubLecture subLecture = lecture.getSubLectures().stream()
+			.filter(session -> session.getRound() == requestDTO.round())
+			.findFirst()
+			.orElseThrow(() -> new IllegalStateException(NO_SUB_LECTURE_EQUAL_ROUND.getName()));
+		subLecture.startAttendance(requestDTO.code());
+
+		return new AttendanceResponseDTO(lecture.getId(), subLecture.getId());
 	}
 
 	@Override
 	@Transactional
-	public void updateMembersScore(Long lectureId) {
-		Lecture lecture = lectureRepository.findById(lectureId)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_LECTURE.getName()));
+	public void finishLecture(Long lectureId) {
+		val lecture = findLecture(lectureId);
 		if (lecture.getEndDate().isAfter(LocalDateTime.now(ZoneId.of("Asia/Seoul")))) {
 			throw new IllegalStateException(NOT_END_TIME_YET.getName());
 		}
-		lecture.getAttendances().forEach(this::updateScoreIn32);
+		lecture.finish();
 	}
 
 	@Override
@@ -255,26 +260,6 @@ public class LectureServiceImpl implements LectureService {
 		}
 
 		return LectureCurrentRoundResponseDTO.of(secondLecture);
-	}
-
-	private void updateScoreIn32(Attendance attendance) {
-		Attribute attribute = attendance.getLecture().getAttribute();
-		Member member = attendance.getMember();
-
-		switch (attribute) {
-			case SEMINAR -> {
-				if (attendance.getStatus().equals(TARDY)) {
-					member.updateScore(-0.5f);
-				} else if (attendance.getStatus().equals(ABSENT)) {
-					member.updateScore(-1);
-				}
-			}
-			case EVENT -> {
-				if (attendance.getStatus().equals(ATTENDANCE)) {
-					member.updateScore(0.5f);
-				}
-			}
-		}
 	}
 
 	private LectureVO getLectureVO(Lecture lecture) {


### PR DESCRIPTION


## Related Issue 🚀
- #110 

## Work Description ✏️
- 출석 관련 세션 상태 데이터를 추가했습니다.
- Lecture 엔티티에 LectureStatus 칼럼을 추가했습니다.
- Lecture: 상태 업데이트 및 세션 종료 메소드를 추가했습니다.
- 점수 갱신 트리거 메소드명을 finishLecture로 변경했습니다. (가독성, 명확성)
- 위 메소드의 로직을 변경 및 리팩토링 했습니다. (상태 값 활용, 구조 리팩토링)
- 세션 생성, 출석 시작, 세션 종료할 경우 해당 세션의 상태 값을 업데이트 했습니다. (BEFORE, FIRST, SECOND, END)

## PR Point 📸
엔티티 칼럼을 추가함에 따라 dev DB에는 lectureStatus 칼럼을 추가해둔 상태입니다.
develop에서 main으로 머지할 때 prod에도 반영하겠습니다.
