### PR TITLE
[FEAT] 세션 상세 조회 API

### DIFF
--- a/src/main/java/org/sopt/makers/operation/controller/web/LectureController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/web/LectureController.java
@@ -77,6 +77,13 @@ public class LectureController {
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_DELETE_LECTURE.getMessage()));
 	}
 
+	@ApiOperation(value = "세션 상세 조회 (팝업)")
+	@GetMapping("/detail/{lectureId}")
+	public ResponseEntity<ApiResponse> getLectureDetail(@PathVariable Long lectureId) {
+		val response = lectureService.getLectureDetail(lectureId);
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_LECTURE.getMessage(), response));
+	}
+
 	private URI getURI(Long lectureId) {
 		return ServletUriComponentsBuilder
 			.fromCurrentRequest()

--- a/src/main/java/org/sopt/makers/operation/dto/lecture/LectureDetailResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/lecture/LectureDetailResponseDTO.java
@@ -1,0 +1,30 @@
+package org.sopt.makers.operation.dto.lecture;
+
+import java.time.LocalDateTime;
+
+import org.sopt.makers.operation.entity.lecture.Lecture;
+
+import lombok.Builder;
+
+@Builder
+public record LectureDetailResponseDTO(
+	Long lectureId,
+	String part,
+	String name,
+	String place,
+	String attribute,
+	LocalDateTime startDate,
+	LocalDateTime endDate
+) {
+	public static LectureDetailResponseDTO of(Lecture lecture) {
+		return LectureDetailResponseDTO.builder()
+			.lectureId(lecture.getId())
+			.part(lecture.getPart().getName())
+			.name(lecture.getName())
+			.place(lecture.getPlace())
+			.attribute(lecture.getAttribute().getName())
+			.startDate(lecture.getStartDate())
+			.endDate(lecture.getEndDate())
+			.build();
+	}
+}

--- a/src/main/java/org/sopt/makers/operation/service/LectureService.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureService.java
@@ -18,5 +18,6 @@ public interface LectureService {
 	void finishLecture(Long lectureId);
 	LectureCurrentRoundResponseDTO getCurrentLectureRound(Long lectureId);
 	void deleteLecture(Long lectureId);
+	LectureDetailResponseDTO getLectureDetail(Long lectureId);
 
 }

--- a/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
@@ -272,6 +272,12 @@ public class LectureServiceImpl implements LectureService {
 		lectureRepository.deleteById(lectureId);
 	}
 
+	@Override
+	public LectureDetailResponseDTO getLectureDetail(Long lectureId) {
+		val lecture = findLecture(lectureId);
+		return LectureDetailResponseDTO.of(lecture);
+	}
+
 	private LectureVO getLectureVO(Lecture lecture) {
 		return LectureVO.of(lecture, getAttendanceVO(lecture));
 	}


### PR DESCRIPTION
## Related Issue 🚀
- closed #124 

## Work Description ✏️
- 세션 상세 조회 API 기능을 구현했습니다.

## PR Point 📸
![image](https://github.com/sopt-makers/sopt-operation-backend/assets/55437339/3f02e683-18eb-4652-9d3a-cc544e8bb205)

![image](https://github.com/sopt-makers/sopt-operation-backend/assets/55437339/e3ef6b34-65b0-4b83-bdc5-a98962e005c7)
배열로 나오는 startDate와 endDate는 LocalDateTime 타입입니다!

