### PR TITLE
[FIX] 세션 삭제 API 수정

### DIFF
--- a/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceCustomRepository.java
+++ b/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceCustomRepository.java
@@ -17,4 +17,5 @@ public interface AttendanceCustomRepository {
 	List<Attendance> findAttendancesByLecture(Long lectureId, Part part, Pageable pageable);
 	List<Attendance> findAttendancesByMember(Long memberId);
 	Optional<Attendance> findAttendanceBySubAttendance(SubAttendance subAttendance);
+	List<Attendance> findByLecture(Lecture lecture);
 }

--- a/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceRepositoryImpl.java
@@ -129,6 +129,16 @@ public class AttendanceRepositoryImpl implements AttendanceCustomRepository {
 			.stream().findFirst();
 	}
 
+	@Override
+	public List<Attendance> findByLecture(Lecture lecture) {
+		return queryFactory
+			.select(attendance)
+			.from(attendance)
+			.leftJoin(attendance.member, member).fetchJoin().distinct()
+			.where(attendance.lecture.eq(lecture))
+			.fetch();
+	}
+
 	private BooleanExpression partEq(Part part) {
 		return (part == null || part.equals(ALL)) ? null : member.part.eq(part);
 	}


### PR DESCRIPTION


## Related Issue 🚀
- closed #126 

## Work Description ✏️
- END 상태의 세션을 삭제할 경우 해당 회원들의 출석 점수를 세션 생성 전 상태로 되돌립니다.
- 예를 들어, 행사 세션 출석으로 0.5점을 받은 회원은 해당 세션이 삭제될 때 -0.5점으로 계산됩니다.

## PR Point 📸
- LAZY 이슈로 인해 AttendanceRepository를 통해 List 데이터를 호출했습니다.
- N+1 문제를 해결하기 위해 findByLecture 메소드에서 Attendance와 Member을 Fetch Join 했습니다.
