### PR TITLE
[FIX] 출석 점수 갱신 API 수정

### DIFF
--- a/src/main/java/org/sopt/makers/operation/entity/Member.java
+++ b/src/main/java/org/sopt/makers/operation/entity/Member.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.operation.entity;
 
+import static org.sopt.makers.operation.entity.lecture.LectureStatus.*;
 import static org.sopt.makers.operation.util.Generation32.*;
 
 import java.util.ArrayList;
@@ -13,6 +14,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+
+import org.sopt.makers.operation.entity.lecture.Lecture;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -66,7 +69,12 @@ public class Member {
 
 	public void updateTotalScore() {
 		this.score = (float) (2 + this.attendances.stream()
-			.mapToDouble(attendance -> getUpdateScore(attendance.getLecture().getAttribute(), attendance.getStatus()))
+			.mapToDouble(attendance -> {
+				Lecture lecture = attendance.getLecture();
+				return lecture.getLectureStatus().equals(END)
+					? getUpdateScore(lecture.getAttribute(), attendance.getStatus())
+					: 0;
+			})
 			.sum());
 	}
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #129 

## Work Description ✏️
- END 상태의 세션 출석 정보만 점수 계산에 포함하도록 예외 처리 추가


