### PR TITLE
[FEAT] 출석 자동 종료 스케줄러

### DIFF
--- a/src/main/java/org/sopt/makers/operation/controller/ScheduleController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/ScheduleController.java
@@ -1,0 +1,24 @@
+package org.sopt.makers.operation.controller;
+
+import org.sopt.makers.operation.service.LectureService;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@EnableScheduling
+@RequiredArgsConstructor
+public class ScheduleController {
+
+	private final LectureService lectureService;
+
+	// @Scheduled(cron = "0 0 0 ? * 7")
+	@Scheduled(cron = "5 * * * * *")
+	public void endLecture() {
+		lectureService.finishLecture();
+		System.out.println("work");
+	}
+
+}

--- a/src/main/java/org/sopt/makers/operation/controller/ScheduleController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/ScheduleController.java
@@ -14,11 +14,9 @@ public class ScheduleController {
 
 	private final LectureService lectureService;
 
-	// @Scheduled(cron = "0 0 0 ? * 7")
-	@Scheduled(cron = "5 * * * * *")
+	@Scheduled(cron = "0 0 0 ? * 7")
 	public void endLecture() {
 		lectureService.finishLecture();
-		System.out.println("work");
 	}
 
 }

--- a/src/main/java/org/sopt/makers/operation/repository/lecture/LectureCustomRepository.java
+++ b/src/main/java/org/sopt/makers/operation/repository/lecture/LectureCustomRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface LectureCustomRepository {
     List<Lecture> findLectures(int generation, Part part);
+    List<Lecture> findLecturesToBeEnd();
 }

--- a/src/main/java/org/sopt/makers/operation/repository/lecture/LectureRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/lecture/LectureRepositoryImpl.java
@@ -7,10 +7,13 @@ import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.entity.lecture.Lecture;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static java.util.Objects.*;
 import static org.sopt.makers.operation.entity.QAttendance.*;
+import static org.sopt.makers.operation.entity.QMember.*;
+import static org.sopt.makers.operation.entity.lecture.LectureStatus.*;
 import static org.sopt.makers.operation.entity.lecture.QLecture.*;
 
 @Repository
@@ -27,6 +30,19 @@ public class LectureRepositoryImpl implements LectureCustomRepository {
                 partEq(part)
             )
             .orderBy(lecture.startDate.desc())
+            .fetch();
+    }
+
+    @Override
+    public List<Lecture> findLecturesToBeEnd() {
+        return queryFactory
+            .selectFrom(lecture)
+            .leftJoin(lecture.attendances, attendance).fetchJoin().distinct()
+            .leftJoin(attendance.member, member).fetchJoin().distinct()
+            .where(
+                lecture.endDate.before(LocalDateTime.now()),
+                lecture.lectureStatus.ne(END)
+            )
             .fetch();
     }
 

--- a/src/main/java/org/sopt/makers/operation/service/LectureService.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureService.java
@@ -16,6 +16,7 @@ public interface LectureService {
 	LectureResponseDTO getLecture(Long lectureId);
 	AttendanceResponseDTO startAttendance(AttendanceRequestDTO requestDTO);
 	void finishLecture(Long lectureId);
+	void finishLecture();
 	LectureCurrentRoundResponseDTO getCurrentLectureRound(Long lectureId);
 	void deleteLecture(Long lectureId);
 	LectureDetailResponseDTO getLectureDetail(Long lectureId);

--- a/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
@@ -178,6 +178,13 @@ public class LectureServiceImpl implements LectureService {
 	}
 
 	@Override
+	@Transactional
+	public void finishLecture() {
+		val lectures = lectureRepository.findLecturesToBeEnd();
+		lectures.forEach(Lecture::finish);
+	}
+
+	@Override
 	public LectureCurrentRoundResponseDTO getCurrentLectureRound(Long lectureId) {
 		val now = LocalDateTime.now();
 		val today = now.toLocalDate();


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #151 

## Work Description ✏️
- 종료됐지만 상태 값이 업데이트 되지 않은 세션의 상태 값을 END 강제 업데이트합니다.
- 매주 일요일 자정(토요일에서 일요일 넘어가는)에 스케줄러를 실행합니다.

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
