### PR TITLE
[ADD] 회원 리스트 조회 페이지네이션 추가

### DIFF
--- a/src/main/java/org/sopt/makers/operation/controller/web/MemberController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/web/MemberController.java
@@ -7,6 +7,7 @@ import lombok.val;
 import org.sopt.makers.operation.common.ApiResponse;
 import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.service.MemberService;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,8 +22,8 @@ public class MemberController {
     @ApiOperation(value = "멤버 리스트 조회")
     @GetMapping("/list")
     public ResponseEntity<ApiResponse> getMemberList(
-        @RequestParam(required = false) Part part, @RequestParam(required = false) Integer generation) {
-        val memberList = memberService.getMemberList(part, generation);
+        @RequestParam(required = false) Part part, @RequestParam(required = false) Integer generation, Pageable pageable) {
+        val memberList = memberService.getMemberList(part, generation, pageable);
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_MEMBERS.getMessage(), memberList));
     }
 }

--- a/src/main/java/org/sopt/makers/operation/repository/member/MemberCustomRepository.java
+++ b/src/main/java/org/sopt/makers/operation/repository/member/MemberCustomRepository.java
@@ -5,8 +5,10 @@ import java.util.Optional;
 
 import org.sopt.makers.operation.dto.member.MemberSearchCondition;
 import org.sopt.makers.operation.entity.Member;
+import org.springframework.data.domain.Pageable;
 
 public interface MemberCustomRepository {
+	List<Member> search(MemberSearchCondition condition, Pageable pageable);
 	List<Member> search(MemberSearchCondition condition);
 	Optional<Member> findMemberByIdFetchJoinAttendances(Long memberId);
 }

--- a/src/main/java/org/sopt/makers/operation/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/member/MemberRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.sopt.makers.operation.dto.member.MemberSearchCondition;
 import org.sopt.makers.operation.entity.Member;
 import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.entity.lecture.QLecture;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -27,6 +28,22 @@ public class MemberRepositoryImpl implements MemberCustomRepository {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
+	public List<Member> search(MemberSearchCondition condition, Pageable pageable) {
+		StringExpression firstName = Expressions.stringTemplate("SUBSTR({0}, 1, 1)", member.name);
+
+		return queryFactory
+			.selectFrom(member)
+			.where(
+				partEq(condition.part()),
+				member.generation.eq(condition.generation())
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+        	.orderBy(firstName.asc())
+			.fetch();
+	}
+
+	@Override
 	public List<Member> search(MemberSearchCondition condition) {
 		StringExpression firstName = Expressions.stringTemplate("SUBSTR({0}, 1, 1)", member.name);
 
@@ -36,7 +53,7 @@ public class MemberRepositoryImpl implements MemberCustomRepository {
 				partEq(condition.part()),
 				member.generation.eq(condition.generation())
 			)
-        	.orderBy(firstName.asc())
+			.orderBy(firstName.asc())
 			.fetch();
 	}
 

--- a/src/main/java/org/sopt/makers/operation/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/operation/service/MemberService.java
@@ -5,11 +5,12 @@ import org.sopt.makers.operation.dto.member.MemberListGetResponse;
 import org.sopt.makers.operation.dto.member.MemberRequestDTO;
 import org.sopt.makers.operation.dto.member.MemberScoreGetResponse;
 import org.sopt.makers.operation.entity.Part;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface MemberService {
-    List<MemberListGetResponse> getMemberList(Part part, int generation);
+    List<MemberListGetResponse> getMemberList(Part part, int generation, Pageable pageable);
     AttendanceTotalResponseDTO getMemberTotalAttendance(Long playGroundId);
     MemberScoreGetResponse getMemberScore(Long playGroundId);
     void createMember(MemberRequestDTO requestDTO);

--- a/src/main/java/org/sopt/makers/operation/service/MemberServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/MemberServiceImpl.java
@@ -19,6 +19,7 @@ import org.sopt.makers.operation.entity.lecture.Attribute;
 import org.sopt.makers.operation.exception.MemberException;
 import org.sopt.makers.operation.repository.attendance.AttendanceRepository;
 import org.sopt.makers.operation.repository.member.MemberRepository;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.EnumMap;
@@ -33,12 +34,12 @@ public class MemberServiceImpl implements MemberService {
     private final AttendanceRepository attendanceRepository;
 
     @Override
-    public List<MemberListGetResponse> getMemberList(Part part, int generation) {
+    public List<MemberListGetResponse> getMemberList(Part part, int generation, Pageable pageable) {
         if(part.equals(Part.ALL)) {
             part = null;
         }
 
-        val members = memberRepository.search(new MemberSearchCondition(part, generation));
+        val members = memberRepository.search(new MemberSearchCondition(part, generation), pageable);
 
         return members.stream().map(member -> {
             val attendances = findAttendances(member);


### PR DESCRIPTION


## Related Issue 🚀
- closed #155 

## Work Description ✏️
- 회원 리스트 조회에 페이지네이션 기능 추가했습니다.
- MemberRepository.search() 메소드를 사용하는 곳이 2곳이어서 인자 기준으로 두 메소드로 분리했습니다. (중복 코드 등 후에 리팩토링 진행하도록 하겠습니다!)

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
