### PR TITLE
[FIX] 앱 토큰 유저 정보 획득시 현재 기수 필터링 되지 않는 오류

### DIFF
--- a/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceRepositoryImpl.java
@@ -20,6 +20,7 @@ import org.sopt.makers.operation.entity.Part;
 import org.sopt.makers.operation.entity.QSubAttendance;
 import org.sopt.makers.operation.entity.SubAttendance;
 import org.sopt.makers.operation.entity.lecture.Lecture;
+import org.sopt.makers.operation.entity.lecture.LectureStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
@@ -37,14 +38,13 @@ public class AttendanceRepositoryImpl implements AttendanceCustomRepository {
 
 	@Override
 	public List<Attendance> findAttendanceByMemberId(Long memberId) {
-		val now = LocalDateTime.now();
 
 		return queryFactory
 				.select(attendance)
 				.from(attendance)
 				.leftJoin(attendance.lecture, lecture)
 				.where(attendance.member.id.eq(memberId),
-						lecture.endDate.before(now),
+						lecture.lectureStatus.eq(LectureStatus.END),
 						lecture.generation.eq(generationConfig.getCurrentGeneration())
 				)
 				.orderBy(attendance.lecture.startDate.desc())

--- a/src/main/java/org/sopt/makers/operation/repository/member/MemberRepository.java
+++ b/src/main/java/org/sopt/makers/operation/repository/member/MemberRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
-    Optional<Member> getMemberByPlaygroundId(Long id);
+    Optional<Member> getMemberByPlaygroundIdAndGeneration(Long id, int generation);
     boolean existsByPlaygroundId(Long id);
 }

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
@@ -23,6 +23,7 @@ import org.sopt.makers.operation.repository.attendance.AttendanceRepository;
 import org.sopt.makers.operation.exception.SubLectureException;
 import org.sopt.makers.operation.repository.lecture.SubLectureRepository;
 import org.sopt.makers.operation.repository.member.MemberRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +41,9 @@ public class AttendanceServiceImpl implements AttendanceService {
 	private final MemberRepository memberRepository;
 	private final SubLectureRepository subLectureRepository;
 	private final AttendanceRepository attendanceRepository;
+
+	@Value("${sopt.current.generation}")
+	private int currentGeneration;
 
 	@Override
 	@Transactional
@@ -77,7 +81,7 @@ public class AttendanceServiceImpl implements AttendanceService {
 	@Override
 	@Transactional
 	public AttendResponseDTO attend(Long playGroundId, AttendRequestDTO requestDTO) {
-		val member = memberRepository.getMemberByPlaygroundId(playGroundId)
+		val member = memberRepository.getMemberByPlaygroundIdAndGeneration(playGroundId, currentGeneration)
 				.orElseThrow(() -> new MemberException(INVALID_MEMBER.getName()));
 
 		val memberId = member.getId();

--- a/src/main/java/org/sopt/makers/operation/service/MemberServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/MemberServiceImpl.java
@@ -19,6 +19,7 @@ import org.sopt.makers.operation.entity.lecture.Attribute;
 import org.sopt.makers.operation.exception.MemberException;
 import org.sopt.makers.operation.repository.attendance.AttendanceRepository;
 import org.sopt.makers.operation.repository.member.MemberRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -32,6 +33,9 @@ import javax.transaction.Transactional;
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
     private final AttendanceRepository attendanceRepository;
+
+    @Value("${sopt.current.generation}")
+    private int currentGeneration;
 
     @Override
     public List<MemberListGetResponse> getMemberList(Part part, int generation, Pageable pageable) {
@@ -51,7 +55,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public AttendanceTotalResponseDTO getMemberTotalAttendance(Long playGroundId) {
-        val member = memberRepository.getMemberByPlaygroundId(playGroundId)
+        val member = memberRepository.getMemberByPlaygroundIdAndGeneration(playGroundId, currentGeneration)
                 .orElseThrow(() -> new MemberException(INVALID_MEMBER.getName()));
 
         val attendances = findAttendances(member);
@@ -65,7 +69,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public MemberScoreGetResponse getMemberScore(Long playGroundId) {
-        val member = memberRepository.getMemberByPlaygroundId(playGroundId)
+        val member = memberRepository.getMemberByPlaygroundIdAndGeneration(playGroundId, currentGeneration)
                 .orElseThrow(() -> new MemberException(INVALID_MEMBER.getName()));
 
         return MemberScoreGetResponse.of(member.getScore());


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #162 

## Work Description ✏️
- 앱 토큰 인증시 현재 기수 필터링을 하지 않고 있었습니다
- 여러기수를 진행한 OB의 경우 여러개의 값이 쿼리가 되어 오류가 발생
- 현재 기수의 정보만 가져오도록 함

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
