### PR TITLE
[FIX] 알림 발송 대상 회원 플그 id null 처리 추가

### DIFF
--- a/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
@@ -186,6 +186,7 @@ public class LectureServiceImpl implements LectureService {
 
 		List<String> memberPgIds = lecture.getAttendances().stream()
 			.map(attendance -> String.valueOf(attendance.getMember().getPlaygroundId()))
+			.filter(id -> !id.equals("null"))
 			.toList();
 		alarmService.send(lecture.getName() + " " + ALARM_MESSAGE_TITLE, ALARM_MESSAGE_CONTENT, memberPgIds, NEWS, null);
 	}
@@ -200,7 +201,10 @@ public class LectureServiceImpl implements LectureService {
 		for (val lecture : lectures) {
 			memberPgIds = new ArrayList<>();
 			for (val attendance : lecture.getAttendances()) {
-				memberPgIds.add(String.valueOf(attendance.getMember().getPlaygroundId()));
+				val playgroundId = attendance.getMember().getPlaygroundId();
+				if (Objects.nonNull(playgroundId)) {
+					memberPgIds.add(String.valueOf(attendance.getMember().getPlaygroundId()));
+				}
 			}
 			alarmService.send(lecture.getName() + " " + ALARM_MESSAGE_TITLE, ALARM_MESSAGE_CONTENT, memberPgIds, NEWS, null);
 		}


### PR DESCRIPTION


## Related Issue 🚀
- closed #195 

## Work Description ✏️
- 회원의 플그 id가 null일 경우 알림 발송에 실패
- null 처리를 추가하여 이슈 해결


