### PR TITLE
[FIX] 포트 포워딩 삭제

### DIFF
--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -22,11 +22,6 @@ sudo service nginx reload
 
 echo "> Nginx reloaded."
 
-sudo iptables -t nat -D PREROUTING 1
-sudo iptables -A PREROUTING -t nat -i eth0 -p tcp --dport 80 -j REDIRECT --to-port ${TARGET_PORT}
-
-echo "> Forward ${TARGET_PORT} port"
-
 CURRENT_PID=$(lsof -Fp -i TCP:${CURRENT_PORT} | grep -Po 'p[0-9]+' | grep -Po '[0-9]+')
 
 sudo kill ${CURRENT_PID}


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #204 

## Work Description ✏️
- certbot webroot 방식을 사용하는데, cron이 지속적으로 실패함
- webroot는 nginx단에 http요청을 보내서 유효성을 확인해서 인증하는 방식
- 해당 명령어 때문에 80포트 요청이 nginx를 안타고 바로 8081,8082 포트로 리다이렉트가 됨
- 인증서가 인증이 안되어 갱신이 안되는 이슈가 발생

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 해당 명령어 무효화 시키고 실행했을 때 갱신이 잘되긴 합니다.
- 이유가 타당한지 의논 필요!