### PR TITLE
[ADD] 응답 데이터 총 개수 추가

### DIFF
--- a/src/main/java/org/sopt/makers/operation/dto/alarm/AlarmsResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/alarm/AlarmsResponseDTO.java
@@ -9,10 +9,11 @@ import org.sopt.makers.operation.entity.alarm.Alarm;
 import lombok.Builder;
 
 public record AlarmsResponseDTO(
-	List<AlarmVO> alarms
+	List<AlarmVO> alarms,
+	int totalCount
 ) {
-	public static AlarmsResponseDTO of(List<Alarm> alarms) {
-		return new AlarmsResponseDTO(alarms.stream().map(AlarmVO::of).toList());
+	public static AlarmsResponseDTO of(List<Alarm> alarms, int totalCount) {
+		return new AlarmsResponseDTO(alarms.stream().map(AlarmVO::of).toList(), totalCount);
 	}
 
 	@Builder

--- a/src/main/java/org/sopt/makers/operation/dto/attendance/AttendancesResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/attendance/AttendancesResponseDTO.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.operation.dto.attendance;
+
+import java.util.List;
+
+import org.sopt.makers.operation.entity.Attendance;
+
+public record AttendancesResponseDTO(
+	List<MemberResponseDTO> attendances,
+	int totalCount
+) {
+	public static AttendancesResponseDTO of(List<Attendance> attendances, int totalCount) {
+		return new AttendancesResponseDTO(
+			attendances.stream().map(MemberResponseDTO::of).toList(),
+			totalCount);
+	}
+}

--- a/src/main/java/org/sopt/makers/operation/dto/member/MembersResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/member/MembersResponseDTO.java
@@ -1,0 +1,12 @@
+package org.sopt.makers.operation.dto.member;
+
+import java.util.List;
+
+public record MembersResponseDTO(
+	List<MemberListGetResponse> members,
+	int totalCount
+) {
+	public static MembersResponseDTO of(List<MemberListGetResponse> members, int totalCount) {
+		return new MembersResponseDTO(members, totalCount);
+	}
+}

--- a/src/main/java/org/sopt/makers/operation/repository/alarm/AlarmCustomRepository.java
+++ b/src/main/java/org/sopt/makers/operation/repository/alarm/AlarmCustomRepository.java
@@ -9,4 +9,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface AlarmCustomRepository {
 	List<Alarm> getAlarms(Integer generation, Part part, Status status, Pageable pageable);
+	int countByGenerationAndPartAndStatus(int generation, Part part, Status status);
 }

--- a/src/main/java/org/sopt/makers/operation/repository/alarm/AlarmRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/alarm/AlarmRepositoryImpl.java
@@ -1,7 +1,6 @@
 package org.sopt.makers.operation.repository.alarm;
 
 import static java.util.Objects.*;
-import static org.sopt.makers.operation.entity.Part.*;
 import static org.sopt.makers.operation.entity.alarm.QAlarm.*;
 
 import java.util.List;
@@ -37,12 +36,25 @@ public class AlarmRepositoryImpl implements AlarmCustomRepository {
 			.fetch();
 	}
 
+	@Override
+	public int countByGenerationAndPartAndStatus(int generation, Part part, Status status) {
+		return Math.toIntExact(queryFactory
+			.select(alarm.count())
+			.from(alarm)
+			.where(
+				generationEq(generation),
+				partEq(part),
+				statusEq(status)
+			)
+			.fetchFirst());
+	}
+
 	private BooleanExpression generationEq(Integer generation) {
 		return nonNull(generation) ? alarm.generation.eq(generation) : null;
 	}
 
 	private BooleanExpression partEq(Part part) {
-		return (nonNull(part) && !part.equals(ALL)) ? alarm.part.eq(part) : null;
+		return nonNull(part) ? alarm.part.eq(part) : null;
 	}
 
 	private BooleanExpression statusEq(Status status) {

--- a/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceCustomRepository.java
+++ b/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceCustomRepository.java
@@ -15,4 +15,5 @@ public interface AttendanceCustomRepository {
 	List<Attendance> findByMember(Member member);
 	List<Attendance> findCurrentAttendanceByMember(Long playGroundId);
 	List<SubAttendance> findSubAttendanceByAttendanceId(Long attendanceId);
+	int countByLectureIdAndPart(long lectureId, Part part);
 }

--- a/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/attendance/AttendanceRepositoryImpl.java
@@ -1,7 +1,7 @@
 package org.sopt.makers.operation.repository.attendance;
 
 import static com.querydsl.core.types.dsl.Expressions.*;
-import static org.sopt.makers.operation.entity.Part.*;
+import static java.util.Objects.*;
 import static org.sopt.makers.operation.entity.QAttendance.*;
 import static org.sopt.makers.operation.entity.QMember.*;
 import static org.sopt.makers.operation.entity.QSubAttendance.*;
@@ -115,7 +115,20 @@ public class AttendanceRepositoryImpl implements AttendanceCustomRepository {
 			.fetch();
 	}
 
+	@Override
+	public int countByLectureIdAndPart(long lectureId, Part part) {
+		return Math.toIntExact(queryFactory
+			.select(attendance.count())
+			.from(attendance)
+			.where(
+				attendance.lecture.id.eq(lectureId),
+				nonNull(part) ? attendance.lecture.part.eq(part) : null
+			)
+			.fetchFirst()
+		);
+	}
+
 	private BooleanExpression partEq(Part part) {
-		return (part == null || part.equals(ALL)) ? null : member.part.eq(part);
+		return nonNull(part) ? member.part.eq(part) : null;
 	}
 }

--- a/src/main/java/org/sopt/makers/operation/repository/member/MemberCustomRepository.java
+++ b/src/main/java/org/sopt/makers/operation/repository/member/MemberCustomRepository.java
@@ -5,10 +5,12 @@ import java.util.Optional;
 
 import org.sopt.makers.operation.dto.member.MemberSearchCondition;
 import org.sopt.makers.operation.entity.Member;
+import org.sopt.makers.operation.entity.Part;
 import org.springframework.data.domain.Pageable;
 
 public interface MemberCustomRepository {
 	List<Member> search(MemberSearchCondition condition, Pageable pageable);
 	List<Member> search(MemberSearchCondition condition);
 	Optional<Member> find(Long memberId);
+	int countByGenerationAndPart(int generation, Part part);
 }

--- a/src/main/java/org/sopt/makers/operation/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/member/MemberRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.operation.repository.member;
 
 import static java.util.Objects.*;
+import static org.sopt.makers.operation.entity.Part.*;
 import static org.sopt.makers.operation.entity.QAttendance.*;
 import static org.sopt.makers.operation.entity.QMember.*;
 import static org.sopt.makers.operation.entity.lecture.QLecture.*;
@@ -65,6 +66,18 @@ public class MemberRepositoryImpl implements MemberCustomRepository {
 			.join(attendance.lecture, lecture).fetchJoin()
 			.where(member.id.eq(memberId))
 			.stream().findFirst();
+	}
+
+	@Override
+	public int countByGenerationAndPart(int generation, Part part) {
+		return Math.toIntExact(queryFactory
+			.select(member.count())
+			.from(member)
+			.where(
+				member.generation.eq(generation),
+				(nonNull(part) && !part.equals(ALL)) ? member.part.eq(part) : null
+			)
+			.fetchFirst());
 	}
 
 	private BooleanExpression partEq(Part part) {

--- a/src/main/java/org/sopt/makers/operation/service/AlarmServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AlarmServiceImpl.java
@@ -146,7 +146,8 @@ public class AlarmServiceImpl implements AlarmService {
 	@Override
 	public AlarmsResponseDTO getAlarms(Integer generation, Part part, Status status, Pageable pageable) {
 		val alarms = alarmRepository.getAlarms(generation, part, status, pageable);
-		return AlarmsResponseDTO.of(alarms);
+		val alarmsCount = alarmRepository.countByGenerationAndPartAndStatus(generation, part, status);
+		return AlarmsResponseDTO.of(alarms, alarmsCount);
 	}
 
 	@Override

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceService.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceService.java
@@ -14,6 +14,6 @@ public interface AttendanceService {
 	SubAttendanceUpdateResponseDTO updateSubAttendance(SubAttendanceUpdateRequestDTO requestDTO);
 	AttendanceMemberResponseDTO findAttendancesByMember(Long memberId);
 	float updateMemberScore(Long memberId);
-	List<MemberResponseDTO> findAttendancesByLecture(Long lectureId, Part part, Pageable pageable);
+	AttendancesResponseDTO findAttendancesByLecture(Long lectureId, Part part, Pageable pageable);
 	AttendResponseDTO attend(Long playGroundId, AttendRequestDTO requestDTO);
 }

--- a/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AttendanceServiceImpl.java
@@ -71,9 +71,10 @@ public class AttendanceServiceImpl implements AttendanceService {
 	}
 
 	@Override
-	public List<MemberResponseDTO> findAttendancesByLecture(Long lectureId, Part part, Pageable pageable) {
+	public AttendancesResponseDTO findAttendancesByLecture(Long lectureId, Part part, Pageable pageable) {
 		val attendances = attendanceRepository.findByLecture(lectureId, part, pageable);
-		return attendances.stream().map(MemberResponseDTO::of).toList();
+		val attendancesCount = attendanceRepository.countByLectureIdAndPart(lectureId, part);
+		return AttendancesResponseDTO.of(attendances, attendancesCount);
 	}
 
 	@Override

--- a/src/main/java/org/sopt/makers/operation/service/MemberService.java
+++ b/src/main/java/org/sopt/makers/operation/service/MemberService.java
@@ -4,13 +4,14 @@ import org.sopt.makers.operation.dto.attendance.AttendanceTotalResponseDTO;
 import org.sopt.makers.operation.dto.member.MemberListGetResponse;
 import org.sopt.makers.operation.dto.member.MemberRequestDTO;
 import org.sopt.makers.operation.dto.member.MemberScoreGetResponse;
+import org.sopt.makers.operation.dto.member.MembersResponseDTO;
 import org.sopt.makers.operation.entity.Part;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface MemberService {
-    List<MemberListGetResponse> getMemberList(Part part, int generation, Pageable pageable);
+    MembersResponseDTO getMemberList(Part part, int generation, Pageable pageable);
     AttendanceTotalResponseDTO getMemberTotalAttendance(Long playGroundId);
     MemberScoreGetResponse getMemberScore(Long playGroundId);
     void createMember(MemberRequestDTO requestDTO);


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #203 

## Work Description ✏️
- 클라이언트 요청입니다.
- Pageable 파라미터가 포함된 URI 기준으로, 조건과 일치하는 데이터의 총 개수 데이터를 추가했습니다.
- totalCount 필드명 통일
- List 타입 자체로 응답하는 API는 새로운 DTO를 생성하여 한 번 감쌌습니다.
- 로컬 기준 테스트 진행했습니다.

## PR Point 📸
- 용택 담당이었던 전체 회원 조회도 요청에 포함되는 API 여서 제 나름대로 수정했습니다. 문제가 있다면 알려주세요! 🙇‍♀️
