### PR TITLE
[FIX] 외부 API 인터페이스 분리

### DIFF
--- a/src/main/java/org/sopt/makers/operation/config/RestTemplateConfig.java
+++ b/src/main/java/org/sopt/makers/operation/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package org.sopt.makers.operation.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/src/main/java/org/sopt/makers/operation/controller/web/AlarmController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/web/AlarmController.java
@@ -39,7 +39,7 @@ public class AlarmController {
 	@ApiOperation(value = "알림 전송")
 	@PostMapping("/send")
 	public ResponseEntity<ApiResponse> sendAlarm(@RequestBody AlarmSendRequestDTO requestDTO) {
-		alarmService.sendAdmin(requestDTO);
+		alarmService.sendByAdmin(requestDTO);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_SEND_ALARM.getMessage()));
 	}
 

--- a/src/main/java/org/sopt/makers/operation/dto/alarm/AlarmSenderDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/alarm/AlarmSenderDTO.java
@@ -1,0 +1,27 @@
+package org.sopt.makers.operation.dto.alarm;
+
+import java.util.List;
+
+import org.sopt.makers.operation.entity.alarm.Alarm;
+import org.sopt.makers.operation.entity.alarm.Attribute;
+
+import lombok.Builder;
+
+@Builder
+public record AlarmSenderDTO(
+	String title,
+	String content,
+	List<String> targetList,
+	Attribute attribute,
+	String link
+) {
+	public static AlarmSenderDTO of (Alarm alarm, List<String> targetList) {
+		return AlarmSenderDTO.builder()
+			.title(alarm.getTitle())
+			.content(alarm.getContent())
+			.targetList(targetList)
+			.attribute(alarm.getAttribute())
+			.link(alarm.getLink())
+			.build();
+	}
+}

--- a/src/main/java/org/sopt/makers/operation/external/api/AlarmSender.java
+++ b/src/main/java/org/sopt/makers/operation/external/api/AlarmSender.java
@@ -1,0 +1,7 @@
+package org.sopt.makers.operation.external.api;
+
+import org.sopt.makers.operation.dto.alarm.AlarmSenderDTO;
+
+public interface AlarmSender {
+	void send(AlarmSenderDTO alarmSenderDTO);
+}

--- a/src/main/java/org/sopt/makers/operation/external/api/AlarmSenderImpl.java
+++ b/src/main/java/org/sopt/makers/operation/external/api/AlarmSenderImpl.java
@@ -1,0 +1,105 @@
+package org.sopt.makers.operation.external.api;
+
+import static java.util.Objects.*;
+import static java.util.UUID.*;
+import static org.sopt.makers.operation.common.ExceptionMessage.*;
+import static org.springframework.http.MediaType.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.sopt.makers.operation.dto.alarm.AlarmSendResponseDTO;
+import org.sopt.makers.operation.dto.alarm.AlarmSenderDTO;
+import org.sopt.makers.operation.exception.AlarmException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+@Component
+@RequiredArgsConstructor
+public class AlarmSenderImpl implements AlarmSender {
+	private final RestTemplate restTemplate;
+
+	@Value("${notification.key}")
+	private String key;
+	@Value("${notification.url}")
+	private String host;
+
+	private final List<String> appLinkList = Arrays.asList(
+		"home",
+		"home/notification",
+		"home/mypage",
+		"home/attendance",
+		"home/attendance/attendance-modal",
+		"home/soptamp",
+		"home/soptamp/entire-ranking",
+		"home/soptamp/current-generation-ranking"
+	);
+	private final List<String> webLinkList = Arrays.asList(
+		"https://playground.sopt.org/members",
+		"https://playground.sopt.org/group"
+	);
+
+	@Override
+	public void send(AlarmSenderDTO alarmSenderDTO) {
+		val alarmRequest = getAlarmRequest(alarmSenderDTO);
+		val headers = getHeaders();
+		val entity = new HttpEntity<>(alarmRequest, headers);
+
+		try {
+			restTemplate.postForEntity(host, entity, AlarmSendResponseDTO.class);
+		} catch (HttpClientErrorException e) {
+			throw new AlarmException(FAIL_SEND_ALARM.getName());
+		}
+	}
+
+	private Map<Object, Object> getAlarmRequest(AlarmSenderDTO alarmSenderDTO) {
+		val alarmRequest = new HashMap<>();
+		val link = alarmSenderDTO.link();
+		val linkKey = getLinkKey(link);
+
+		if (!linkKey.isEmpty()) {
+			alarmRequest.put(linkKey, link);
+		}
+
+		alarmRequest.put("userIds", alarmSenderDTO.targetList());
+		alarmRequest.put("title", alarmSenderDTO.title());
+		alarmRequest.put("content", alarmSenderDTO.content());
+		alarmRequest.put("category", alarmSenderDTO.attribute());
+
+		return alarmRequest;
+	}
+
+	private String getLinkKey(String link) {
+		if (nonNull(link)) {
+			if (appLinkList.contains(link)) {
+				return "appLink";
+			} else if (webLinkList.contains(link)) {
+				return "webLink";
+			}
+		}
+		return "";
+	}
+
+	private HttpHeaders getHeaders() {
+		val headers = new HttpHeaders();
+
+		headers.setContentType(APPLICATION_JSON);
+		headers.setAccept(Collections.singletonList(APPLICATION_JSON));
+		headers.add("action", "send");
+		headers.add("transactionId", randomUUID().toString());
+		headers.add("service", "operation");
+		headers.add("x-api-key", key);
+
+		return headers;
+	}
+}

--- a/src/main/java/org/sopt/makers/operation/external/api/PlayGround.java
+++ b/src/main/java/org/sopt/makers/operation/external/api/PlayGround.java
@@ -1,0 +1,4 @@
+package org.sopt.makers.operation.external.api;
+
+public interface PlayGround {
+}

--- a/src/main/java/org/sopt/makers/operation/external/api/PlayGround.java
+++ b/src/main/java/org/sopt/makers/operation/external/api/PlayGround.java
@@ -1,4 +1,0 @@
-package org.sopt.makers.operation.external.api;
-
-public interface PlayGround {
-}

--- a/src/main/java/org/sopt/makers/operation/external/api/PlayGroundServer.java
+++ b/src/main/java/org/sopt/makers/operation/external/api/PlayGroundServer.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.operation.external.api;
+
+import org.sopt.makers.operation.dto.alarm.AlarmInactiveListResponseDTO;
+import org.sopt.makers.operation.entity.Part;
+
+public interface PlayGroundServer {
+	AlarmInactiveListResponseDTO getInactiveMembers(int generation, Part part);
+}

--- a/src/main/java/org/sopt/makers/operation/external/api/PlayGroundServerImpl.java
+++ b/src/main/java/org/sopt/makers/operation/external/api/PlayGroundServerImpl.java
@@ -1,0 +1,63 @@
+package org.sopt.makers.operation.external.api;
+
+import static org.sopt.makers.operation.common.ExceptionMessage.*;
+import static org.sopt.makers.operation.entity.Part.*;
+import static org.springframework.http.HttpMethod.*;
+
+import org.sopt.makers.operation.dto.alarm.AlarmInactiveListResponseDTO;
+import org.sopt.makers.operation.entity.Part;
+import org.sopt.makers.operation.exception.AlarmException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+@Component
+@RequiredArgsConstructor
+public class PlayGroundServerImpl implements PlayGroundServer {
+	private final RestTemplate restTemplate;
+
+	@Value("${sopt.makers.playground.server}")
+	private String playGroundURI;
+	@Value("${sopt.makers.playground.token}")
+	private String playGroundToken;
+
+	@Override
+	public AlarmInactiveListResponseDTO getInactiveMembers(int generation, Part part) {
+		val uri = getInactiveUserURI(part, generation);
+		val headers = getHeaders();
+		val entity = new HttpEntity<>(null, headers);
+
+		try {
+			val response = restTemplate.exchange(uri, GET, entity, AlarmInactiveListResponseDTO.class);
+			return response.getBody();
+		} catch (Exception e) {
+			throw new AlarmException(FAIL_INACTIVE_USERS.getName());
+		}
+	}
+
+	private String getInactiveUserURI(Part part, int generation) {
+		val uri = new StringBuilder();
+
+		uri.append(playGroundURI)
+			.append("/internal/api/v1/members/inactivity?generation=")
+			.append(generation);
+
+		if (!part.equals(ALL)) {
+			uri.append("&part=").append(part);
+		}
+
+		return uri.toString();
+	}
+
+	private HttpHeaders getHeaders() {
+		val headers = new HttpHeaders();
+		headers.add("content-type", "application/json;charset=UTF-8");
+		headers.add("Authorization", playGroundToken);
+		return headers;
+	}
+}

--- a/src/main/java/org/sopt/makers/operation/service/AlarmService.java
+++ b/src/main/java/org/sopt/makers/operation/service/AlarmService.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface AlarmService {
 	void sendAdmin(AlarmSendRequestDTO requestDTO);
-	void send(String title, String content, List<String> targetList, Attribute attribute, String link);
 	Long createAlarm(AlarmRequestDTO requestDTO);
 	AlarmsResponseDTO getAlarms(Integer generation, Part part, Status status, Pageable pageable);
 	AlarmResponseDTO getAlarm(Long alarmId);

--- a/src/main/java/org/sopt/makers/operation/service/AlarmService.java
+++ b/src/main/java/org/sopt/makers/operation/service/AlarmService.java
@@ -13,7 +13,7 @@ import org.sopt.makers.operation.entity.alarm.Status;
 import org.springframework.data.domain.Pageable;
 
 public interface AlarmService {
-	void sendAdmin(AlarmSendRequestDTO requestDTO);
+	void sendByAdmin(AlarmSendRequestDTO requestDTO);
 	Long createAlarm(AlarmRequestDTO requestDTO);
 	AlarmsResponseDTO getAlarms(Integer generation, Part part, Status status, Pageable pageable);
 	AlarmResponseDTO getAlarm(Long alarmId);

--- a/src/main/java/org/sopt/makers/operation/service/AlarmServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/AlarmServiceImpl.java
@@ -52,7 +52,7 @@ public class AlarmServiceImpl implements AlarmService {
 
 	@Override
 	@Transactional
-	public void sendAdmin(AlarmSendRequestDTO requestDTO) {
+	public void sendByAdmin(AlarmSendRequestDTO requestDTO) {
 		val alarm = alarmRepository.findById(requestDTO.alarmId())
 			.orElseThrow(() -> new EntityNotFoundException(INVALID_ALARM.getName()));
 

--- a/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
+++ b/src/main/java/org/sopt/makers/operation/service/LectureServiceImpl.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 
 import lombok.val;
 
+import org.sopt.makers.operation.dto.alarm.AlarmSenderDTO;
 import org.sopt.makers.operation.dto.lecture.*;
 
 import org.sopt.makers.operation.dto.lecture.AttendanceRequestDTO;
@@ -26,6 +27,7 @@ import org.sopt.makers.operation.entity.*;
 import org.sopt.makers.operation.entity.lecture.Attribute;
 import org.sopt.makers.operation.entity.lecture.Lecture;
 import org.sopt.makers.operation.exception.LectureException;
+import org.sopt.makers.operation.external.api.AlarmSender;
 import org.sopt.makers.operation.repository.attendance.AttendanceRepository;
 import org.sopt.makers.operation.repository.SubAttendanceRepository;
 import org.sopt.makers.operation.repository.lecture.LectureRepository;
@@ -46,7 +48,7 @@ public class LectureServiceImpl implements LectureService {
 	private final AttendanceRepository attendanceRepository;
 	private final SubAttendanceRepository subAttendanceRepository;
 	private final MemberRepository memberRepository;
-	private final AlarmService alarmService;
+	private final AlarmSender alarmSender;
 
 	@Value("${sopt.alarm.message.title_end}")
 	private String ALARM_MESSAGE_TITLE;
@@ -188,7 +190,9 @@ public class LectureServiceImpl implements LectureService {
 			.map(attendance -> String.valueOf(attendance.getMember().getPlaygroundId()))
 			.filter(id -> !id.equals("null"))
 			.toList();
-		alarmService.send(lecture.getName() + " " + ALARM_MESSAGE_TITLE, ALARM_MESSAGE_CONTENT, memberPgIds, NEWS, null);
+
+		val alarmTitle = lecture.getName() + " " + ALARM_MESSAGE_TITLE;
+		alarmSender.send(new AlarmSenderDTO(alarmTitle, ALARM_MESSAGE_CONTENT, memberPgIds, NEWS, null));
 	}
 
 	@Override
@@ -206,7 +210,9 @@ public class LectureServiceImpl implements LectureService {
 					memberPgIds.add(String.valueOf(attendance.getMember().getPlaygroundId()));
 				}
 			}
-			alarmService.send(lecture.getName() + " " + ALARM_MESSAGE_TITLE, ALARM_MESSAGE_CONTENT, memberPgIds, NEWS, null);
+
+			val alarmTitle = lecture.getName() + " " + ALARM_MESSAGE_TITLE;
+			alarmSender.send(new AlarmSenderDTO(alarmTitle, ALARM_MESSAGE_CONTENT, memberPgIds, NEWS, null));
 		}
 	}
 


### PR DESCRIPTION


## Related Issue 🚀
- closed #209 

## Work Description ✏️
- 외부 API 인터페이스를 분리했습니다. (알림 전송, 비활동 회원 조회)
- (특히 인수인계 과정에서) 유지보수와 가독성을 위해 외부 API를 따로 관리하는 패키지 및 인터페이스로 분리했습니다.
- RestTemplate은 Bean으로 등록했습니다. DI를 적용함으로써 의존도를 낮추기 위해 고려했습니다.
- 변수, 메서드 이름을 변경했습니다. `직관적인 이름인가?` `전체적인 코드 스타일에 통일되는가?`를 위주로 우선 개인적으로 판단하여 변경했습니다. 다른 의견이 있다면 리뷰 부탁드려요!
- 인터페이스 분리 과정에서 단일 책임 원칙을 적용하기 위해 한 메서드가 하나의 기능을 담당하도록 최대한 분리하고자 했습니다.

## PR Point 📸
- 우선 제 담당이 아니었던 코드에 대해 리팩토링 작업을 수행하여 죄송해요. 곧 있을 인수인계를 효율적으로 대처하고 싶은 생각에서 좀 더 유지보수에 유리한 설계 구조를 생각하며 적용하고자 했어요. 해당 작업과 관련해서 용택님의 의견을 적극적으로 수용하도록 하겠습니다!
- 외부 API를 별도의 인터페이스로 분리하는 방식에 대한 의견이 궁금해요.
- 특히 변경된 변수, 메서드 이름에 대해서 생각하시는 의견이 궁금해요.
- 그 외 다른 의견, 추가적인 의견, 궁금한 점 등등 모두 편하게 리뷰로 알려주시면 감사하겠습니다!
