### PR TITLE
[ADD] PR 이어받아 추가 작업

### DIFF
--- a/src/main/java/org/sopt/makers/operation/controller/app/AppScheduleController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/app/AppScheduleController.java
@@ -16,7 +16,7 @@ import static org.sopt.makers.operation.common.ResponseMessage.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/app/schedules")
+@RequestMapping("/api/v1/schedules")
 public class AppScheduleController {
     private final ScheduleService scheduleService;
 

--- a/src/main/java/org/sopt/makers/operation/controller/app/AppScheduleController.java
+++ b/src/main/java/org/sopt/makers/operation/controller/app/AppScheduleController.java
@@ -16,7 +16,7 @@ import static org.sopt.makers.operation.common.ResponseMessage.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/schedules")
+@RequestMapping("/api/v1/app/schedules")
 public class AppScheduleController {
     private final ScheduleService scheduleService;
 

--- a/src/main/java/org/sopt/makers/operation/dto/schedule/SchedulesResponseDTO.java
+++ b/src/main/java/org/sopt/makers/operation/dto/schedule/SchedulesResponseDTO.java
@@ -1,25 +1,39 @@
 package org.sopt.makers.operation.dto.schedule;
 
-import lombok.Builder;
+import lombok.*;
 import org.sopt.makers.operation.entity.lecture.Attribute;
 import org.sopt.makers.operation.entity.schedule.Schedule;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.format.TextStyle;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public record SchedulesResponseDTO(
-        Map<LocalDateTime, List<ScheduleVO>> calendar
+    List<DateVO> dates
 ) {
+    public static SchedulesResponseDTO of(Map<LocalDate, List<Schedule>> scheduleMap) {
+        return new SchedulesResponseDTO(
+            scheduleMap.keySet().stream().sorted()
+                .map(key -> DateVO.of(key, scheduleMap.get(key)))
+                .toList()
+        );
+    }
 
-    public static SchedulesResponseDTO of(Map<LocalDateTime, List<Schedule>> calendar) {
-        Map<LocalDateTime, List<ScheduleVO>> convertedCalendar = calendar.entrySet().stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        entry -> entry.getValue().stream().map(ScheduleVO::of).collect(Collectors.toList())
-                ));
-        return new SchedulesResponseDTO(convertedCalendar);
+    @Builder
+    record DateVO(
+        String date,
+        String dayOfWeek,
+        List<ScheduleVO> schedules
+    ) {
+        static DateVO of(LocalDate date, List<Schedule> schedules) {
+            return DateVO.builder()
+                .date(date.toString())
+                .dayOfWeek(date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN))
+                .schedules(schedules.stream().map(ScheduleVO::of).toList())
+                .build();
+        }
     }
 
     @Builder

--- a/src/main/java/org/sopt/makers/operation/entity/schedule/Schedule.java
+++ b/src/main/java/org/sopt/makers/operation/entity/schedule/Schedule.java
@@ -20,7 +20,7 @@ public class Schedule extends BaseEntity {
     @Column(name = "schedule_id")
     private Long id;
 
-    private LocalDateTime date;
+    private LocalDateTime date; // TODO : 필요한 칼럼인가?
 
     private LocalDateTime startDate;
 

--- a/src/main/java/org/sopt/makers/operation/entity/schedule/Schedule.java
+++ b/src/main/java/org/sopt/makers/operation/entity/schedule/Schedule.java
@@ -20,8 +20,6 @@ public class Schedule extends BaseEntity {
     @Column(name = "schedule_id")
     private Long id;
 
-    private LocalDateTime date; // TODO : 필요한 칼럼인가?
-
     private LocalDateTime startDate;
 
     private LocalDateTime endDate;

--- a/src/main/java/org/sopt/makers/operation/repository/schedule/ScheduleCustomRepository.java
+++ b/src/main/java/org/sopt/makers/operation/repository/schedule/ScheduleCustomRepository.java
@@ -6,5 +6,5 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleCustomRepository {
-    List<Schedule> find(LocalDateTime start, LocalDateTime end);
+    List<Schedule> findBetweenStartAndEnd(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/org/sopt/makers/operation/repository/schedule/ScheduleRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/schedule/ScheduleRepositoryImpl.java
@@ -1,7 +1,10 @@
 package org.sopt.makers.operation.repository.schedule;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import lombok.RequiredArgsConstructor;
+
 import org.sopt.makers.operation.entity.schedule.Schedule;
 import org.springframework.stereotype.Repository;
 
@@ -21,7 +24,10 @@ public class ScheduleRepositoryImpl implements ScheduleCustomRepository {
 		return queryFactory
 			.select(schedule)
 			.from(schedule)
-			.where(schedule.date.between(start, end))
+			.where(
+				schedule.startDate.between(start, end)
+					.or(schedule.endDate.between(start, end))
+			)
 			.orderBy(schedule.startDate.asc())
 			.fetch();
 	}

--- a/src/main/java/org/sopt/makers/operation/repository/schedule/ScheduleRepositoryImpl.java
+++ b/src/main/java/org/sopt/makers/operation/repository/schedule/ScheduleRepositoryImpl.java
@@ -7,8 +7,6 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.sopt.makers.operation.entity.schedule.QSchedule.schedule;
 
@@ -19,11 +17,12 @@ public class ScheduleRepositoryImpl implements ScheduleCustomRepository {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public List<Schedule> find(LocalDateTime start, LocalDateTime end) {
+	public List<Schedule> findBetweenStartAndEnd(LocalDateTime start, LocalDateTime end) {
 		return queryFactory
-				.select(schedule)
-				.from(schedule)
-				.where(schedule.date.between(start, end))
-				.fetch();
+			.select(schedule)
+			.from(schedule)
+			.where(schedule.date.between(start, end))
+			.orderBy(schedule.startDate.asc())
+			.fetch();
 	}
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
...

## Work Description ✏️
- 슬랙으로 전달해준 2가지 사항 반영했어요!
  - DTO 내 날짜 요일 정보 추가 (디자인을 참고해서 한글 줄임 형식으로 들어가는 것 확인하고, 같은 형식으로 일치시켰어요.)
  - DTO 형식 List로 변경 (Map 형식에서 List 형식으로 변경했어요.)
- (현재 슬랙으로 논의 중이긴 하나) 일정 데이터가 없는 날짜 데이터까지 내려주면 비효율적인 응답 데이터가 많아질 것으로 생각하여 일정이 존재하는 날짜만 내려주는 것으로 변경했어요. 차후 논의 내용이 다른 방향으로 달라지면 되돌려놓도록 할게요!
- startDate 기준으로 오름차순, 날짜 기준으로 오름차순 정렬 반영했어요.
- Scheduler 엔티티의 `LocalDateTime date` 칼럼은 어디서 사용되는 값일까요?? startDate로 충분히 판단 가능할 것 같아 해당 칼럼은 의미가 없다고 생각해서 개인적으로 삭제하는 방향이 좋을 것 같아요. 이 부분에 대해서 용택님 의견도 부탁드려요! 우선 삭제하진 않고 TODO 남겨놓았어요.
- 기간이 1, 2일 넘어가는 일정 고려하여 비즈니스 로직 추가 작업 수행했어요.
- 그 외 모호한 메서드명은 좀 더 구체적으로 보완하고, 메서드 분리 작업 수행했어요.

## PR Point 📸
사소한 의견부터 큰 의견까지 자유롭게 리뷰 부탁드려요 :)
의논 일치 및 반영 후 PR 머지하도록 할게요!


아래 API 테스트 결과
<img width="976" alt="image" src="https://github.com/sopt-makers/sopt-operation-backend/assets/55437339/15b63f44-a532-4ce5-9926-8f81f6cb811e">

```
{
    "success": true,
    "message": "일정 리스트 조회 성공",
    "data": {
        "dates": [
            {
                "date": "2023-12-23",
                "dayOfWeek": "토",
                "schedules": [
                    {
                        "scheduleId": 3,
                        "startDate": "2023-12-23T09:00",
                        "endDate": "2023-12-23T22:00",
                        "attribute": "SEMINAR",
                        "title": "10차 세미나"
                    },
                    {
                        "scheduleId": 1,
                        "startDate": "2023-12-23T09:00",
                        "endDate": "2023-12-24T12:00",
                        "attribute": "EVENT",
                        "title": "솝커톤"
                    },
                    {
                        "scheduleId": 2,
                        "startDate": "2023-12-23T18:00:40",
                        "endDate": "2023-12-23T22:00",
                        "attribute": "SEMINAR",
                        "title": "11차 세미나 뒷풀이"
                    },
                    {
                        "scheduleId": 4,
                        "startDate": "2023-12-23T18:00:40",
                        "endDate": "2023-12-23T22:00",
                        "attribute": "SEMINAR",
                        "title": "10차 세미나 뒷풀이"
                    }
                ]
            },
            {
                "date": "2023-12-24",
                "dayOfWeek": "일",
                "schedules": [
                    {
                        "scheduleId": 1,
                        "startDate": "2023-12-23T09:00",
                        "endDate": "2023-12-24T12:00",
                        "attribute": "EVENT",
                        "title": "솝커톤"
                    }
                ]
            },
            {
                "date": "2023-12-26",
                "dayOfWeek": "화",
                "schedules": [
                    {
                        "scheduleId": 5,
                        "startDate": "2023-12-26T09:00",
                        "endDate": "2023-12-26T22:00",
                        "attribute": "SEMINAR",
                        "title": "9차 세미나"
                    }
                ]
            }
        ]
    }
}
```