### PR TITLE
[FIX] iOS 무한로딩 원인 DTO 롤백

### DIFF
--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/lecture/LectureFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/lecture/LectureFailureCode.java
@@ -14,7 +14,7 @@ public enum LectureFailureCode implements FailureCode {
     INVALID_ATTENDANCE(BAD_REQUEST,"존재하지 않는 출석 세션입니다."),
     ENDED_ATTENDANCE(BAD_REQUEST, "차 출석이 이미 종료되었습니다."),
     ENDED_FIRST_ATTENDANCE(BAD_REQUEST, "1차 출석이 이미 종료되었습니다."),
-    ENDED_SECOND_ATTENDANCE(BAD_REQUEST, "차 출석이 이미 종료되었습니다."),
+    ENDED_SECOND_ATTENDANCE(BAD_REQUEST, "2차 출석이 이미 종료되었습니다."),
     INVALID_COUNT_SESSION(BAD_REQUEST,"세션의 개수가 올바르지 않습니다."),
     INVALID_LECTURE(BAD_REQUEST,"존재하지 않는 세션입니다."),
     NO_SESSION(BAD_REQUEST,"오늘 세션이 없습니다."),

--- a/operation-common/src/main/java/org/sopt/makers/operation/dto/BaseResponse.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/dto/BaseResponse.java
@@ -1,8 +1,6 @@
 package org.sopt.makers.operation.dto;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,7 +9,7 @@ import lombok.Builder;
 public record BaseResponse<T> (
 	boolean success,
 	String message,
-	@JsonInclude(value = NON_NULL)
+//	@JsonInclude(value = NON_NULL)
 	T data
 ) {
 

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/AlarmSenderImpl.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/AlarmSenderImpl.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class AlarmSenderImpl implements AlarmSender {
 			val host = valueConfig.getNOTIFICATION_URL();
 			val entity = getEntity(request);
 			restTemplate.postForEntity(host, entity, AlarmSenderRequest.class);
-		} catch (HttpClientErrorException e) {
+		} catch (HttpServerErrorException | HttpClientErrorException e) {
 			throw new AlarmException(FAIL_SEND_ALARM);
 		}
 	}


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #249 
- Closes T-10697

## Work Description ✏️
iOS 무한 로딩 이슈 해결을 위해 Response DTO 내 `data` 필드 nullable 하게끔 롤백했습니다.

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
