### PR TITLE
[TEST] 출석 관련 단위 테스트 추가 및 행사 출석 로직 수정

### DIFF
--- a/operation-domain/build.gradle
+++ b/operation-domain/build.gradle
@@ -25,4 +25,7 @@ dependencies {
 
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0-rc1'
+
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/attendance/domain/Attendance.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/attendance/domain/Attendance.java
@@ -110,7 +110,7 @@ public class Attendance {
 					yield 0f;
 				}
 			}
-			case EVENT -> this.status.equals(ATTENDANCE) ? 0.5f : 0f;
+			case EVENT -> this.status.equals(ABSENT) ? 0f : 0.5f;
 			default -> 0f;
 		};
 	}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/attendance/domain/Attendance.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/attendance/domain/Attendance.java
@@ -86,13 +86,12 @@ public class Attendance {
 		val second = getSubAttendanceByRound(2);
 
 		return switch (this.lecture.getAttribute()) {
-			case SEMINAR -> {
+			case SEMINAR, EVENT -> {
 				if (first.getStatus().equals(ATTENDANCE) && second.getStatus().equals(ATTENDANCE)) {
 					yield ATTENDANCE;
 				}
 				yield first.getStatus().equals(ABSENT) && second.getStatus().equals(ABSENT) ? ABSENT : TARDY;
 			}
-			case EVENT -> second.getStatus().equals(ATTENDANCE) ? ATTENDANCE : ABSENT;
 			case ETC -> second.getStatus().equals(ATTENDANCE) ? PARTICIPATE : NOT_PARTICIPATE;
 		};
 	}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/attendance/domain/Attendance.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/attendance/domain/Attendance.java
@@ -48,6 +48,13 @@ public class Attendance {
 	@OneToMany(mappedBy = "attendance")
 	private final List<SubAttendance> subAttendances = new ArrayList<>();
 
+    protected Attendance(Long id, Member member, Lecture lecture, AttendanceStatus status) {
+        this.id = id;
+        setMember(member);
+        setLecture(lecture);
+        this.status = status;
+    }
+
 	public Attendance(Member member, Lecture lecture) {
 		setMember(member);
 		setLecture(lecture);

--- a/operation-domain/src/main/java/org/sopt/makers/operation/attendance/domain/SubAttendance.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/attendance/domain/SubAttendance.java
@@ -47,6 +47,13 @@ public class SubAttendance extends BaseEntity {
 		status = ABSENT;
 	}
 
+	protected SubAttendance(Long id, Attendance attendance, SubLecture subLecture, AttendanceStatus status) {
+		this.id = id;
+		setAttendance(attendance);
+		setSubLecture(subLecture);
+		this.status = status;
+	}
+
 	private void setAttendance(Attendance attendance) {
 		if (Objects.nonNull(this.attendance)) {
 			this.attendance.getSubAttendances().remove(this);

--- a/operation-domain/src/main/java/org/sopt/makers/operation/lecture/domain/Lecture.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/lecture/domain/Lecture.java
@@ -77,6 +77,18 @@ public class Lecture extends BaseEntity {
 		this.lectureStatus = BEFORE;
 	}
 
+	protected Lecture(Long id, String name, Part part, int generation, String place, LocalDateTime startDate, LocalDateTime endDate, Attribute attribute, LectureStatus lectureStatus) {
+		this.id = id;
+		this.name = name;
+		this.part = part;
+		this.generation = generation;
+		this.place = place;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.attribute = attribute;
+		this.lectureStatus = lectureStatus;
+	}
+
 	public void updateStatus(LectureStatus status) {
 		this.lectureStatus = status;
 	}
@@ -100,5 +112,10 @@ public class Lecture extends BaseEntity {
 
 	public boolean isNotYetToEnd() {
 		return this.endDate.isAfter(LocalDateTime.now());
+	}
+
+	protected void setOneToMany(List<SubLecture> subLectures, List<Attendance> attendances) {
+		this.subLectures = subLectures;
+		this.attendances = attendances;
 	}
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/lecture/domain/SubLecture.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/lecture/domain/SubLecture.java
@@ -43,6 +43,14 @@ public class SubLecture {
 	@OneToMany(mappedBy = "subLecture")
 	private final List<SubAttendance> subAttendances = new ArrayList<>();
 
+    protected SubLecture(Long id, Lecture lecture, int round, LocalDateTime startAt, String code) {
+        this.id = id;
+        setLecture(lecture);
+        this.round = round;
+        this.startAt = startAt;
+        this.code = code;
+    }
+
 	public SubLecture(Lecture lecture, int round) {
 		setLecture(lecture);
 		this.round = round;

--- a/operation-domain/src/main/java/org/sopt/makers/operation/member/domain/Member.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/member/domain/Member.java
@@ -45,6 +45,19 @@ public class Member {
 	@OneToMany(mappedBy = "member")
 	List<Attendance> attendances = new ArrayList<>();
 
+	protected Member(Long id, Long playgroundId, String name, int generation, ObYb obyb, Part part, String university, float score, String phone, List<Attendance> attendances) {
+		this.id = id;
+		this.playgroundId = playgroundId;
+		this.name = name;
+		this.generation = generation;
+		this.obyb = obyb;
+		this.part = part;
+		this.university = university;
+		this.score = score;
+		this.phone = phone;
+		this.attendances = attendances;
+	}
+
 	public void updateScore(float score) {
 		this.score += score;
 	}

--- a/operation-domain/src/test/java/org/sopt/makers/operation/attendance/domain/AttendanceGetScoreTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/attendance/domain/AttendanceGetScoreTest.java
@@ -1,0 +1,124 @@
+package org.sopt.makers.operation.attendance.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.operation.common.domain.Part;
+import org.sopt.makers.operation.dummy.AttendanceDummy;
+import org.sopt.makers.operation.dummy.LectureDummy;
+import org.sopt.makers.operation.dummy.MemberDummy;
+import org.sopt.makers.operation.lecture.domain.Attribute;
+import org.sopt.makers.operation.lecture.domain.Lecture;
+import org.sopt.makers.operation.lecture.domain.LectureStatus;
+import org.sopt.makers.operation.member.domain.Member;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class AttendanceGetScoreTest {
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberDummy.builder()
+                .id(1L)
+                .attendances(new ArrayList<>())
+                .build();
+    }
+
+    @Nested
+    @DisplayName("세미나 출석 관련 테스트")
+    public class SeminarTest {
+        @Test
+        @DisplayName("세미나에 출석을 했으면 0f를 반환한다.")
+        public void getScoreTest() {
+            // given
+            Lecture lecture = new LectureDummy(1L, "서버 1차 세미나", Part.SERVER, 34, "오산역", LocalDateTime.now(), LocalDateTime.now(), Attribute.SEMINAR, LectureStatus.BEFORE);
+            Attendance attendance = new AttendanceDummy(1L, member, lecture, AttendanceStatus.ATTENDANCE);
+
+            // when
+            float score = attendance.getScore();
+
+            // then
+            assertThat(score).isEqualTo(0f);
+        }
+
+        @Test
+        @DisplayName("세미나에 지각을 했으면 -0.5f를 반환한다.")
+        public void getScoreTest2() {
+            // given
+            Lecture lecture = new LectureDummy(1L, "서버 1차 세미나", Part.SERVER, 34, "오산역", LocalDateTime.now(), LocalDateTime.now(), Attribute.SEMINAR, LectureStatus.BEFORE);
+            Attendance attendance = new AttendanceDummy(1L, member, lecture, AttendanceStatus.TARDY);
+
+            // when
+            float score = attendance.getScore();
+
+            // then
+            assertThat(score).isEqualTo(-0.5f);
+        }
+
+        @Test
+        @DisplayName("세미나에 결석을 했으면 -1f를 반환한다.")
+        public void getScoreTest3() {
+            // given
+            Lecture lecture = new LectureDummy(1L, "서버 1차 세미나", Part.SERVER, 34, "오산역", LocalDateTime.now(), LocalDateTime.now(), Attribute.SEMINAR, LectureStatus.BEFORE);
+            Attendance attendance = new AttendanceDummy(1L, member, lecture, AttendanceStatus.ABSENT);
+
+            // when
+            float score = attendance.getScore();
+
+            // then
+            assertThat(score).isEqualTo(-1f);
+        }
+    }
+
+    @Nested
+    @DisplayName("행사 출석 관련 테스트")
+    public class EventTest {
+        @Test
+        @DisplayName("행사에 출석을 했으면 0.5f를 반환한다.")
+        public void getScoreTest() {
+            // given
+            Lecture lecture = new LectureDummy(1L, "서버 1차 세미나", Part.SERVER, 34, "오산역", LocalDateTime.now(), LocalDateTime.now(), Attribute.EVENT, LectureStatus.BEFORE);
+            Attendance attendance = new AttendanceDummy(1L, member, lecture, AttendanceStatus.ATTENDANCE);
+
+            // when
+            float score = attendance.getScore();
+
+            // then
+            assertThat(score).isEqualTo(0.5f);
+        }
+
+        @Test
+        @DisplayName("행사에 지각을 했으면 0.5f를 반환한다.")
+        public void getScoreTest2() {
+            // given
+            Lecture lecture = new LectureDummy(1L, "서버 1차 세미나", Part.SERVER, 34, "오산역", LocalDateTime.now(), LocalDateTime.now(), Attribute.EVENT, LectureStatus.BEFORE);
+            Attendance attendance = new AttendanceDummy(1L, member, lecture, AttendanceStatus.TARDY);
+
+            // when
+            float score = attendance.getScore();
+
+            // then
+            assertThat(score).isEqualTo(0.5f);
+        }
+
+        @Test
+        @DisplayName("행사에 결석을 했으면 0f를 반환한다.")
+        public void getScoreTest3() {
+            // given
+            Lecture lecture = new LectureDummy(1L, "서버 1차 세미나", Part.SERVER, 34, "오산역", LocalDateTime.now(), LocalDateTime.now(), Attribute.EVENT, LectureStatus.BEFORE);
+            Attendance attendance = new AttendanceDummy(1L, member, lecture, AttendanceStatus.ABSENT);
+
+            // when
+            float score = attendance.getScore();
+
+            // then
+            assertThat(score).isEqualTo(0f);
+        }
+    }
+}

--- a/operation-domain/src/test/java/org/sopt/makers/operation/attendance/domain/AttendanceGetScoreTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/attendance/domain/AttendanceGetScoreTest.java
@@ -31,7 +31,7 @@ public class AttendanceGetScoreTest {
     }
 
     @Nested
-    @DisplayName("세미나 출석 관련 테스트")
+    @DisplayName("[세미나 출석 점수 반환 테스트]")
     public class SeminarTest {
         @Test
         @DisplayName("세미나에 출석을 했으면 0f를 반환한다.")
@@ -77,7 +77,7 @@ public class AttendanceGetScoreTest {
     }
 
     @Nested
-    @DisplayName("행사 출석 관련 테스트")
+    @DisplayName("[행사 출석 점수 반환 테스트]")
     public class EventTest {
         @Test
         @DisplayName("행사에 출석을 했으면 0.5f를 반환한다.")

--- a/operation-domain/src/test/java/org/sopt/makers/operation/attendance/domain/AttendanceGetStatusTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/attendance/domain/AttendanceGetStatusTest.java
@@ -1,0 +1,112 @@
+package org.sopt.makers.operation.attendance.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.operation.common.domain.Part;
+import org.sopt.makers.operation.dummy.AttendanceDummy;
+import org.sopt.makers.operation.dummy.LectureDummy;
+import org.sopt.makers.operation.dummy.MemberDummy;
+import org.sopt.makers.operation.dummy.SubAttendanceDummy;
+import org.sopt.makers.operation.dummy.SubLectureDummy;
+import org.sopt.makers.operation.lecture.domain.Attribute;
+import org.sopt.makers.operation.lecture.domain.LectureStatus;
+import org.sopt.makers.operation.lecture.domain.SubLecture;
+import org.sopt.makers.operation.member.domain.Member;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class AttendanceGetStatusTest {
+
+    private Member member;
+    private LectureDummy lecture;
+    private SubLecture subLecture1;
+    private SubLecture subLecture2;
+    private List<SubLecture> subLectures;
+    private List<Attendance> attendances;
+    private Attendance attendance;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberDummy.builder()
+                .id(1L)
+                .attendances(new ArrayList<>())
+                .build();
+
+        lecture = new LectureDummy(1L, "서버 1차 세미나", Part.SERVER, 34, "오산역", LocalDateTime.now(), LocalDateTime.now(), Attribute.SEMINAR, LectureStatus.BEFORE);
+
+        subLecture1 = new SubLectureDummy(1L, lecture, 1, LocalDateTime.now(), "000001");
+        subLecture2 = new SubLectureDummy(2L, lecture, 2, LocalDateTime.now(), "000002");
+
+        subLectures = new ArrayList<>();
+        subLectures.add(subLecture1);
+        subLectures.add(subLecture2);
+
+        attendances = new ArrayList<>();
+        attendance = new AttendanceDummy(1L, member, lecture, AttendanceStatus.ABSENT);
+        attendances.add(attendance);
+
+        lecture.setOneToMany(subLectures, attendances);
+    }
+
+    @Test
+    @DisplayName("세미나 1차 출석을 했고, 2차 출석을 했으면 출석 처리가 된다.")
+    void getStatusTest() {
+        // given
+        SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ATTENDANCE);
+        SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ATTENDANCE);
+
+        // when
+        AttendanceStatus attendanceStatus = attendance.getStatus();
+
+        // then
+        assertThat(attendanceStatus).isEqualTo(AttendanceStatus.ATTENDANCE);
+    }
+
+    @Test
+    @DisplayName("세미나에서 1차 출석을 했고, 2차 출석을 결석했으면 지각 처리가 된다.")
+    void getStatusTest2() {
+        // given
+        SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ATTENDANCE);
+        SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ABSENT);
+
+        // when
+        AttendanceStatus attendanceStatus = attendance.getStatus();
+
+        // then
+        assertThat(attendanceStatus).isEqualTo(AttendanceStatus.TARDY);
+    }
+
+    @Test
+    @DisplayName("세미나에서 1차 출석을 결석했고, 2차 출석을 했으면 지각 처리가 된다.")
+    void getStatusTest3() {
+        // given
+        SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ABSENT);
+        SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ATTENDANCE);
+
+        // when
+        AttendanceStatus attendanceStatus = attendance.getStatus();
+
+        // then
+        assertThat(attendanceStatus).isEqualTo(AttendanceStatus.TARDY);
+    }
+
+    @Test
+    @DisplayName("세미나에서 1차 출석을 결석했고, 2차 출석을 결석했으면 결석 처리가 된다.")
+    void getStatusTest4() {
+        // given
+        SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ABSENT);
+        SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ABSENT);
+
+        // when
+        AttendanceStatus attendanceStatus = attendance.getStatus();
+
+        // then
+        assertThat(attendanceStatus).isEqualTo(AttendanceStatus.ABSENT);
+    }
+
+}

--- a/operation-domain/src/test/java/org/sopt/makers/operation/attendance/domain/AttendanceGetStatusTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/attendance/domain/AttendanceGetStatusTest.java
@@ -2,6 +2,7 @@ package org.sopt.makers.operation.attendance.domain;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.sopt.makers.operation.common.domain.Part;
 import org.sopt.makers.operation.dummy.AttendanceDummy;
@@ -30,83 +31,169 @@ class AttendanceGetStatusTest {
     private List<Attendance> attendances;
     private Attendance attendance;
 
-    @BeforeEach
-    void setUp() {
-        member = MemberDummy.builder()
-                .id(1L)
-                .attendances(new ArrayList<>())
-                .build();
+    @Nested
+    @DisplayName("[세미나 출석 상태 반환 테스트]")
+    public class SeminarTest {
+        @BeforeEach
+        void setUp() {
+            member = MemberDummy.builder()
+                    .id(1L)
+                    .attendances(new ArrayList<>())
+                    .build();
 
-        lecture = new LectureDummy(1L, "서버 1차 세미나", Part.SERVER, 34, "오산역", LocalDateTime.now(), LocalDateTime.now(), Attribute.SEMINAR, LectureStatus.BEFORE);
+            lecture = new LectureDummy(1L, "서버 1차 세미나", Part.SERVER, 34, "오산역", LocalDateTime.now(), LocalDateTime.now(), Attribute.SEMINAR, LectureStatus.BEFORE);
 
-        subLecture1 = new SubLectureDummy(1L, lecture, 1, LocalDateTime.now(), "000001");
-        subLecture2 = new SubLectureDummy(2L, lecture, 2, LocalDateTime.now(), "000002");
+            subLecture1 = new SubLectureDummy(1L, lecture, 1, LocalDateTime.now(), "000001");
+            subLecture2 = new SubLectureDummy(2L, lecture, 2, LocalDateTime.now(), "000002");
 
-        subLectures = new ArrayList<>();
-        subLectures.add(subLecture1);
-        subLectures.add(subLecture2);
+            subLectures = new ArrayList<>();
+            subLectures.add(subLecture1);
+            subLectures.add(subLecture2);
 
-        attendances = new ArrayList<>();
-        attendance = new AttendanceDummy(1L, member, lecture, AttendanceStatus.ABSENT);
-        attendances.add(attendance);
+            attendances = new ArrayList<>();
+            attendance = new AttendanceDummy(1L, member, lecture, AttendanceStatus.ABSENT);
+            attendances.add(attendance);
 
-        lecture.setOneToMany(subLectures, attendances);
+            lecture.setOneToMany(subLectures, attendances);
+        }
+
+        @Test
+        @DisplayName("세미나 1차 출석을 했고, 2차 출석을 했으면 출석 처리가 된다.")
+        void getStatusTest() {
+            // given
+            SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ATTENDANCE);
+            SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ATTENDANCE);
+
+            // when
+            AttendanceStatus attendanceStatus = attendance.getStatus();
+
+            // then
+            assertThat(attendanceStatus).isEqualTo(AttendanceStatus.ATTENDANCE);
+        }
+
+        @Test
+        @DisplayName("세미나에서 1차 출석을 했고, 2차 출석을 결석했으면 지각 처리가 된다.")
+        void getStatusTest2() {
+            // given
+            SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ATTENDANCE);
+            SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ABSENT);
+
+            // when
+            AttendanceStatus attendanceStatus = attendance.getStatus();
+
+            // then
+            assertThat(attendanceStatus).isEqualTo(AttendanceStatus.TARDY);
+        }
+
+        @Test
+        @DisplayName("세미나에서 1차 출석을 결석했고, 2차 출석을 했으면 지각 처리가 된다.")
+        void getStatusTest3() {
+            // given
+            SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ABSENT);
+            SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ATTENDANCE);
+
+            // when
+            AttendanceStatus attendanceStatus = attendance.getStatus();
+
+            // then
+            assertThat(attendanceStatus).isEqualTo(AttendanceStatus.TARDY);
+        }
+
+        @Test
+        @DisplayName("세미나에서 1차 출석을 결석했고, 2차 출석을 결석했으면 결석 처리가 된다.")
+        void getStatusTest4() {
+            // given
+            SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ABSENT);
+            SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ABSENT);
+
+            // when
+            AttendanceStatus attendanceStatus = attendance.getStatus();
+
+            // then
+            assertThat(attendanceStatus).isEqualTo(AttendanceStatus.ABSENT);
+        }
     }
 
-    @Test
-    @DisplayName("세미나 1차 출석을 했고, 2차 출석을 했으면 출석 처리가 된다.")
-    void getStatusTest() {
-        // given
-        SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ATTENDANCE);
-        SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ATTENDANCE);
+    @Nested
+    @DisplayName("[행사 출석 상태 반환 테스트]")
+    public class EventTest {
+        @BeforeEach
+        void setUp() {
+            member = MemberDummy.builder()
+                    .id(1L)
+                    .attendances(new ArrayList<>())
+                    .build();
 
-        // when
-        AttendanceStatus attendanceStatus = attendance.getStatus();
+            lecture = new LectureDummy(1L, "1차 행사", Part.SERVER, 34, "오산역", LocalDateTime.now(), LocalDateTime.now(), Attribute.EVENT, LectureStatus.BEFORE);
 
-        // then
-        assertThat(attendanceStatus).isEqualTo(AttendanceStatus.ATTENDANCE);
+            subLecture1 = new SubLectureDummy(1L, lecture, 1, LocalDateTime.now(), "000001");
+            subLecture2 = new SubLectureDummy(2L, lecture, 2, LocalDateTime.now(), "000002");
+
+            subLectures = new ArrayList<>();
+            subLectures.add(subLecture1);
+            subLectures.add(subLecture2);
+
+            attendances = new ArrayList<>();
+            attendance = new AttendanceDummy(1L, member, lecture, AttendanceStatus.ABSENT);
+            attendances.add(attendance);
+
+            lecture.setOneToMany(subLectures, attendances);
+        }
+
+        @Test
+        @DisplayName("행사 1차 출석을 했고, 2차 출석을 했으면 출석 처리가 된다.")
+        void getStatusTest() {
+            // given
+            SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ATTENDANCE);
+            SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ATTENDANCE);
+
+            // when
+            AttendanceStatus attendanceStatus = attendance.getStatus();
+
+            // then
+            assertThat(attendanceStatus).isEqualTo(AttendanceStatus.ATTENDANCE);
+        }
+
+        @Test
+        @DisplayName("행사에서 1차 출석을 했고, 2차 출석을 결석했으면 지각 처리가 된다.")
+        void getStatusTest2() {
+            // given
+            SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ATTENDANCE);
+            SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ABSENT);
+
+            // when
+            AttendanceStatus attendanceStatus = attendance.getStatus();
+
+            // then
+            assertThat(attendanceStatus).isEqualTo(AttendanceStatus.TARDY);
+        }
+
+        @Test
+        @DisplayName("행사에서 1차 출석을 결석했고, 2차 출석을 했으면 지각 처리가 된다.")
+        void getStatusTest3() {
+            // given
+            SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ABSENT);
+            SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ATTENDANCE);
+
+            // when
+            AttendanceStatus attendanceStatus = attendance.getStatus();
+
+            // then
+            assertThat(attendanceStatus).isEqualTo(AttendanceStatus.TARDY);
+        }
+
+        @Test
+        @DisplayName("행사에서 1차 출석을 결석했고, 2차 출석을 결석했으면 결석 처리가 된다.")
+        void getStatusTest4() {
+            // given
+            SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ABSENT);
+            SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ABSENT);
+
+            // when
+            AttendanceStatus attendanceStatus = attendance.getStatus();
+
+            // then
+            assertThat(attendanceStatus).isEqualTo(AttendanceStatus.ABSENT);
+        }
     }
-
-    @Test
-    @DisplayName("세미나에서 1차 출석을 했고, 2차 출석을 결석했으면 지각 처리가 된다.")
-    void getStatusTest2() {
-        // given
-        SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ATTENDANCE);
-        SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ABSENT);
-
-        // when
-        AttendanceStatus attendanceStatus = attendance.getStatus();
-
-        // then
-        assertThat(attendanceStatus).isEqualTo(AttendanceStatus.TARDY);
-    }
-
-    @Test
-    @DisplayName("세미나에서 1차 출석을 결석했고, 2차 출석을 했으면 지각 처리가 된다.")
-    void getStatusTest3() {
-        // given
-        SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ABSENT);
-        SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ATTENDANCE);
-
-        // when
-        AttendanceStatus attendanceStatus = attendance.getStatus();
-
-        // then
-        assertThat(attendanceStatus).isEqualTo(AttendanceStatus.TARDY);
-    }
-
-    @Test
-    @DisplayName("세미나에서 1차 출석을 결석했고, 2차 출석을 결석했으면 결석 처리가 된다.")
-    void getStatusTest4() {
-        // given
-        SubAttendance subAttendance1 = new SubAttendanceDummy(1L, attendance, subLecture1, AttendanceStatus.ABSENT);
-        SubAttendance subAttendance2 = new SubAttendanceDummy(2L, attendance, subLecture2, AttendanceStatus.ABSENT);
-
-        // when
-        AttendanceStatus attendanceStatus = attendance.getStatus();
-
-        // then
-        assertThat(attendanceStatus).isEqualTo(AttendanceStatus.ABSENT);
-    }
-
 }

--- a/operation-domain/src/test/java/org/sopt/makers/operation/dummy/AttendanceDummy.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/dummy/AttendanceDummy.java
@@ -1,0 +1,12 @@
+package org.sopt.makers.operation.dummy;
+
+import org.sopt.makers.operation.attendance.domain.Attendance;
+import org.sopt.makers.operation.attendance.domain.AttendanceStatus;
+import org.sopt.makers.operation.lecture.domain.Lecture;
+import org.sopt.makers.operation.member.domain.Member;
+
+public class AttendanceDummy extends Attendance {
+    public AttendanceDummy(Long id, Member member, Lecture lecture, AttendanceStatus status) {
+        super(id, member, lecture, status);
+    }
+}

--- a/operation-domain/src/test/java/org/sopt/makers/operation/dummy/LectureDummy.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/dummy/LectureDummy.java
@@ -1,0 +1,22 @@
+package org.sopt.makers.operation.dummy;
+
+import org.sopt.makers.operation.attendance.domain.Attendance;
+import org.sopt.makers.operation.common.domain.Part;
+import org.sopt.makers.operation.lecture.domain.Attribute;
+import org.sopt.makers.operation.lecture.domain.Lecture;
+import org.sopt.makers.operation.lecture.domain.LectureStatus;
+import org.sopt.makers.operation.lecture.domain.SubLecture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class LectureDummy extends Lecture {
+
+    public LectureDummy(Long id, String name, Part part, int generation, String place, LocalDateTime startDate, LocalDateTime endDate, Attribute attribute, LectureStatus lectureStatus) {
+        super(id, name, part, generation, place, startDate, endDate, attribute, lectureStatus);
+    }
+
+    public void setOneToMany(List<SubLecture> subLectures, List<Attendance> attendances) {
+        super.setOneToMany(subLectures, attendances);
+    }
+}

--- a/operation-domain/src/test/java/org/sopt/makers/operation/dummy/MemberDummy.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/dummy/MemberDummy.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.operation.dummy;
+
+import lombok.Builder;
+import org.sopt.makers.operation.attendance.domain.Attendance;
+import org.sopt.makers.operation.common.domain.Part;
+import org.sopt.makers.operation.member.domain.Member;
+import org.sopt.makers.operation.member.domain.ObYb;
+
+import java.util.List;
+
+public class MemberDummy extends Member {
+    @Builder
+    public MemberDummy(Long id, Long playgroundId, String name, int generation, ObYb obyb, Part part, String university, float score, String phone, List<Attendance> attendances) {
+        super(id, playgroundId, name, generation, obyb, part, university, score, phone, attendances);
+    }
+}

--- a/operation-domain/src/test/java/org/sopt/makers/operation/dummy/SubAttendanceDummy.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/dummy/SubAttendanceDummy.java
@@ -1,0 +1,13 @@
+package org.sopt.makers.operation.dummy;
+
+import org.sopt.makers.operation.attendance.domain.Attendance;
+import org.sopt.makers.operation.attendance.domain.AttendanceStatus;
+import org.sopt.makers.operation.attendance.domain.SubAttendance;
+import org.sopt.makers.operation.lecture.domain.SubLecture;
+
+public class SubAttendanceDummy extends SubAttendance {
+
+    public SubAttendanceDummy(Long id, Attendance attendance, SubLecture subLecture, AttendanceStatus status) {
+        super(id, attendance, subLecture, status);
+    }
+}

--- a/operation-domain/src/test/java/org/sopt/makers/operation/dummy/SubLectureDummy.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/dummy/SubLectureDummy.java
@@ -1,0 +1,13 @@
+package org.sopt.makers.operation.dummy;
+
+import org.sopt.makers.operation.lecture.domain.Lecture;
+import org.sopt.makers.operation.lecture.domain.SubLecture;
+
+import java.time.LocalDateTime;
+
+public class SubLectureDummy extends SubLecture {
+
+    public SubLectureDummy(Long id, Lecture lecture, int round, LocalDateTime startAt, String code) {
+        super(id, lecture, round, startAt, code);
+    }
+}


### PR DESCRIPTION
## Related Issue 🚀
- closed #253 

## Work Description ✏️

- 이번에 출석 관련 로직이 수정됨에 따라서 추후에 또 수정할 일이 있을 때 빠르게 검사하기 위해서 테스트 코드를 추가했습니다.
- 단위 테스트시 도메인을 생성하기 위해서 실제 비즈니스 로직에 영향이 안가도록 도메인 내에 protected 생성자를 만든 후에 도메인 객체를 상속 받는 Dummy 객체를 만들었습니다.
- Attendance 도메인 내에 존재하는 getScore 함수와 getStatus 함수의 단위 테스트를 작성했습니다.
- 행사도 지각시 0.5 점을 부여하기 때문에 도메인 로직을 수정했습니다.

## PR Point 📸

`@DisplayName` 테스트명이 괜찮은지 궁금합니다
