### PR TITLE
T-10855 [feat] GET /authorize API 구현

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -31,6 +31,12 @@ jobs:
           echo "${{ secrets.APPLICATION_DEV }}" >> ./application-dev.yml
           cat ./application-dev.yml
 
+      - name: 'Get key from Github Secrets'
+        run: |
+          pwd
+          mkdir -p ./operation-api/src/main/resources/static
+          echo "${{ secrets.APPLE_KEY }}" | base64 --decode > ./operation-api/src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+
       - name: Build with Gradle
         run: ./gradlew build
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Get key from Github Secrets'
         run: |
           mkdir -p src/main/resources/static
-          echo ${{ secrets.APPLE_KEY }} | base64 --decode > src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          echo "${{ secrets.APPLE_KEY }}" | base64 --decode > ./src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Get key from Github Secrets'
         run: |
           mkdir -p src/main/resources/static
-          echo "${{ secrets.APPLE_KEY }}" | base64 --decode > ./src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          echo ${{ secrets.APPLE_KEY }} | base64 -d > ./src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,9 @@ jobs:
 
       - name: 'Get key from Github Secrets'
         run: |
-          mkdir -p src/main/resources/static
-          echo ${{ secrets.APPLE_KEY }} | base64 --decode > src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          pwd
+          mkdir -p ./operation-api/src/main/resources/static
+          echo ${{ secrets.APPLE_KEY }} | base64 --decode > ./operation-api/src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Get key from Github Secrets'
         run: |
           mkdir -p src/main/resources/static
-          echo "${{ secrets.APPLE_KEY }}" | base64 -d > ./src/main/resources/static/"${{ secrets.APPLE_KEY_NAME }}"
+          echo ${{ secrets.APPLE_KEY }} | base64 -d > ./src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pwd
           mkdir -p ./operation-api/src/main/resources/static
-          echo "${{ secrets.APPLE_KEY }}" | base64 -D > ./operation-api/src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          echo "${{ secrets.APPLE_KEY }}" | base64 --decode > ./operation-api/src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
           echo "${{ secrets.APPLICATION_DEV }}" >> ./application-dev.yml
           cat ./application-dev.yml
 
+      - name: 'Get key from Github Secrets'
+        run: |
+          mkdir -p src/main/resources/static
+          echo ${{ secrets.APPLE_KEY }} | base64 --decode > src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+
       - name: Build with Gradle
         run: ./gradlew build
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Get key from Github Secrets'
         run: |
           mkdir -p src/main/resources/static
-          echo ${{ secrets.APPLE_KEY }} | base64 -d > ./src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          echo "${{ secrets.APPLE_KEY }}" | base64 -d > src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Get key from Github Secrets'
         run: |
           mkdir -p src/main/resources/static
-          echo "${{ secrets.APPLE_KEY }}" | tr -d '\n' | base64 --decode > src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          printf "%s" "${{ secrets.APPLE_KEY }}" | base64 --decode > src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Get key from Github Secrets'
         run: |
           mkdir -p src/main/resources/static
-          printf "%s" "${{ secrets.APPLE_KEY }}" | base64 --decode > src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          echo ${{ secrets.APPLE_KEY }} | base64 --decode > src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pwd
           mkdir -p ./operation-api/src/main/resources/static
-          echo "${{ secrets.APPLE_KEY }}" | base64 -d > ./operation-api/src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          echo "${{ secrets.APPLE_KEY }}" | base64 -D > ./operation-api/src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pwd
           mkdir -p ./operation-api/src/main/resources/static
-          echo ${{ secrets.APPLE_KEY }} | base64 --decode > ./operation-api/src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          echo "${{ secrets.APPLE_KEY }}" | base64 -d > ./operation-api/src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Get key from Github Secrets'
         run: |
           mkdir -p src/main/resources/static
-          echo ${{ secrets.APPLE_KEY }} | base64 -d > ./src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          echo "${{ secrets.APPLE_KEY }}" | base64 -d > ./src/main/resources/static/"${{ secrets.APPLE_KEY_NAME }}"
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Get key from Github Secrets'
         run: |
           mkdir -p src/main/resources/static
-          echo "${{ secrets.APPLE_KEY }}" | base64 -d > src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
+          echo "${{ secrets.APPLE_KEY }}" | tr -d '\n' | base64 --decode > src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/operation-api/build.gradle
+++ b/operation-api/build.gradle
@@ -21,4 +21,8 @@ dependencies {
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+    // jwt builder library
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    runtimeOnly "io.jsonwebtoken:jjwt-impl:0.11.2"
+    runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.11.2"
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApi.java
@@ -1,0 +1,47 @@
+package org.sopt.makers.operation.auth.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.sopt.makers.operation.dto.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface AuthApi {
+    @Operation(
+            security = @SecurityRequirement(name = "Authorization"),
+            summary = "플랫폼 인가코드 반환 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "플랫폼 인가코드 반환 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = """
+                                    쿼리 파라미터 중 데이터가 들어오지 않았습니다.
+                                    유효하지 않은 social type 입니다.
+                                    유효하지 않은 id token 입니다.
+                                    유효하지 않은 social code 입니다.
+                                    """
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = """
+                                    등록되지 않은 팀입니다.
+                                    등록된 소셜 정보가 없습니다.
+                                    """
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 내부 오류"
+                    )
+            }
+    )
+    ResponseEntity<BaseResponse<?>> authorize(
+            @RequestParam String type,
+            @RequestParam String code,
+            @RequestParam String clientId,
+            @RequestParam String redirectUri
+    );
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApi.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
 public interface AuthApi {
+
     @Operation(
             security = @SecurityRequirement(name = "Authorization"),
             summary = "플랫폼 인가코드 반환 API",

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApi.java
@@ -28,8 +28,8 @@ public interface AuthApi {
                     @ApiResponse(
                             responseCode = "404",
                             description = """
-                                    등록되지 않은 팀입니다.
-                                    등록된 소셜 정보가 없습니다.
+                                    1. 등록되지 않은 팀입니다.\n
+                                    2. 등록된 소셜 정보가 없습니다.
                                     """
                     ),
                     @ApiResponse(

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApi.java
@@ -19,10 +19,10 @@ public interface AuthApi {
                     @ApiResponse(
                             responseCode = "400",
                             description = """
-                                    쿼리 파라미터 중 데이터가 들어오지 않았습니다.
-                                    유효하지 않은 social type 입니다.
-                                    유효하지 않은 id token 입니다.
-                                    유효하지 않은 social code 입니다.
+                                    1. 쿼리 파라미터 중 데이터가 들어오지 않았습니다.\n
+                                    2. 유효하지 않은 social type 입니다.\n
+                                    3. 유효하지 않은 id token 입니다.\n
+                                    4. 유효하지 않은 social code 입니다.
                                     """
                     ),
                     @ApiResponse(

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.INVALID_SOCIAL_TYPE;
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_FOUNT_REGISTERED_TEAM;
-import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_NULL_PARAMS;
 import static org.sopt.makers.operation.code.success.auth.AuthSuccessCode.SUCCESS_GET_AUTHORIZATION_CODE;
 
 @RestController
@@ -35,9 +34,6 @@ public class AuthApiController implements AuthApi {
             @RequestParam String clientId,
             @RequestParam String redirectUri
     ) {
-        if (checkParamsIsNull(type, code, clientId, redirectUri)) {
-            throw new AuthException(NOT_NULL_PARAMS);
-        }
         if (!authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)) {
             throw new AuthException(NOT_FOUNT_REGISTERED_TEAM);
         }
@@ -48,15 +44,6 @@ public class AuthApiController implements AuthApi {
         val userId = findUserIdBySocialTypeAndCode(type, code);
         val platformCode = generatePlatformCode(clientId, redirectUri, userId);
         return ApiResponseUtil.success(SUCCESS_GET_AUTHORIZATION_CODE, new AuthorizationCodeResponse(platformCode));
-    }
-
-    private boolean checkParamsIsNull(String... params) {
-        for (String param : params) {
-            if (param == null) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private Long findUserIdBySocialTypeAndCode(String type, String code) {

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -1,0 +1,66 @@
+package org.sopt.makers.operation.auth.api;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.makers.operation.auth.dto.response.AuthorizationCodeResponse;
+import org.sopt.makers.operation.auth.service.AuthService;
+import org.sopt.makers.operation.dto.BaseResponse;
+import org.sopt.makers.operation.exception.AuthException;
+import org.sopt.makers.operation.user.domain.SocialType;
+import org.sopt.makers.operation.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.INVALID_SOCIAL_TYPE;
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_NULL_PARAMS;
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_FOUNT_REGISTERED_TEAM;
+import static org.sopt.makers.operation.code.success.auth.AuthSuccessCode.SUCCESS_GET_AUTHORIZATION_CODE;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class AuthApiController implements AuthApi {
+    private final ConcurrentHashMap<String, String> tempPlatformCode = new ConcurrentHashMap<>();
+    private final AuthService authService;
+
+    @Override
+    @GetMapping("/authorize")
+    public ResponseEntity<BaseResponse<?>> authorize(
+            @RequestParam String type,
+            @RequestParam String code,
+            @RequestParam String clientId,
+            @RequestParam String redirectUri
+    ) {
+        if (checkParamsIsNull(type, code, clientId, redirectUri)) throw new AuthException(NOT_NULL_PARAMS);
+        if (authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)) throw new AuthException(NOT_FOUNT_REGISTERED_TEAM);
+        if (!SocialType.isContains(type)) throw new AuthException(INVALID_SOCIAL_TYPE);
+
+        val userId = findUserIdBySocialTypeAndCode(type, code);
+        val platformCode = generatePlatformCode(userId);
+        return ApiResponseUtil.success(SUCCESS_GET_AUTHORIZATION_CODE, new AuthorizationCodeResponse(platformCode));
+    }
+
+    private boolean checkParamsIsNull(String... params) {
+        for (String param : params) {
+            if (param == null) return true;
+        }
+        return false;
+    }
+
+    private Long findUserIdBySocialTypeAndCode(String type, String code) {
+        val socialType = SocialType.valueOf(type);
+        val userSocialId = authService.getSocialUserInfo(socialType, code);
+        return authService.getUserId(socialType, userSocialId);
+    }
+
+    private String generatePlatformCode(Long userId) {
+        val platformCode = authService.generatePlatformCode(userId);
+        tempPlatformCode.putIfAbsent(platformCode, platformCode);
+        return platformCode;
+    }
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -40,7 +40,7 @@ public class AuthApiController implements AuthApi {
         if (!SocialType.isContains(type)) throw new AuthException(INVALID_SOCIAL_TYPE);
 
         val userId = findUserIdBySocialTypeAndCode(type, code);
-        val platformCode = generatePlatformCode(userId);
+        val platformCode = generatePlatformCode(clientId, redirectUri, userId);
         return ApiResponseUtil.success(SUCCESS_GET_AUTHORIZATION_CODE, new AuthorizationCodeResponse(platformCode));
     }
 
@@ -57,8 +57,8 @@ public class AuthApiController implements AuthApi {
         return authService.getUserId(socialType, userSocialId);
     }
 
-    private String generatePlatformCode(Long userId) {
-        val platformCode = authService.generatePlatformCode(userId);
+    private String generatePlatformCode(String clientId, String redirectUri, Long userId) {
+        val platformCode = authService.generatePlatformCode(clientId, redirectUri, userId);
         tempPlatformCode.putIfAbsent(platformCode, platformCode);
         return platformCode;
     }

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -23,6 +23,7 @@ import static org.sopt.makers.operation.code.success.auth.AuthSuccessCode.SUCCES
 @RestController
 @RequiredArgsConstructor
 public class AuthApiController implements AuthApi {
+
     private final ConcurrentHashMap<String, String> tempPlatformCode = new ConcurrentHashMap<>();
     private final AuthService authService;
 
@@ -34,10 +35,15 @@ public class AuthApiController implements AuthApi {
             @RequestParam String clientId,
             @RequestParam String redirectUri
     ) {
-        if (checkParamsIsNull(type, code, clientId, redirectUri)) throw new AuthException(NOT_NULL_PARAMS);
-        if (authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri))
+        if (checkParamsIsNull(type, code, clientId, redirectUri)) {
+            throw new AuthException(NOT_NULL_PARAMS);
+        }
+        if (authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)) {
             throw new AuthException(NOT_FOUNT_REGISTERED_TEAM);
-        if (!SocialType.isContains(type)) throw new AuthException(INVALID_SOCIAL_TYPE);
+        }
+        if (!SocialType.isContains(type)) {
+            throw new AuthException(INVALID_SOCIAL_TYPE);
+        }
 
         val userId = findUserIdBySocialTypeAndCode(type, code);
         val platformCode = generatePlatformCode(clientId, redirectUri, userId);
@@ -46,7 +52,9 @@ public class AuthApiController implements AuthApi {
 
     private boolean checkParamsIsNull(String... params) {
         for (String param : params) {
-            if (param == null) return true;
+            if (param == null) {
+                return true;
+            }
         }
         return false;
     }

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -38,7 +38,7 @@ public class AuthApiController implements AuthApi {
         if (checkParamsIsNull(type, code, clientId, redirectUri)) {
             throw new AuthException(NOT_NULL_PARAMS);
         }
-        if (authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)) {
+        if (!authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)) {
             throw new AuthException(NOT_FOUNT_REGISTERED_TEAM);
         }
         if (!SocialType.isContains(type)) {

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -10,26 +10,24 @@ import org.sopt.makers.operation.user.domain.SocialType;
 import org.sopt.makers.operation.util.ApiResponseUtil;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.INVALID_SOCIAL_TYPE;
-import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_NULL_PARAMS;
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_FOUNT_REGISTERED_TEAM;
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_NULL_PARAMS;
 import static org.sopt.makers.operation.code.success.auth.AuthSuccessCode.SUCCESS_GET_AUTHORIZATION_CODE;
 
 @RestController
-@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class AuthApiController implements AuthApi {
     private final ConcurrentHashMap<String, String> tempPlatformCode = new ConcurrentHashMap<>();
     private final AuthService authService;
 
     @Override
-    @GetMapping("/authorize")
+    @GetMapping("/api/v1/authorize")
     public ResponseEntity<BaseResponse<?>> authorize(
             @RequestParam String type,
             @RequestParam String code,
@@ -37,7 +35,8 @@ public class AuthApiController implements AuthApi {
             @RequestParam String redirectUri
     ) {
         if (checkParamsIsNull(type, code, clientId, redirectUri)) throw new AuthException(NOT_NULL_PARAMS);
-        if (authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)) throw new AuthException(NOT_FOUNT_REGISTERED_TEAM);
+        if (authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri))
+            throw new AuthException(NOT_FOUNT_REGISTERED_TEAM);
         if (!SocialType.isContains(type)) throw new AuthException(INVALID_SOCIAL_TYPE);
 
         val userId = findUserIdBySocialTypeAndCode(type, code);

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/dto/response/AuthorizationCodeResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/dto/response/AuthorizationCodeResponse.java
@@ -1,0 +1,4 @@
+package org.sopt.makers.operation.auth.dto.response;
+
+public record AuthorizationCodeResponse(String platformCode) {
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthService.java
@@ -1,0 +1,13 @@
+package org.sopt.makers.operation.auth.service;
+
+import org.sopt.makers.operation.user.domain.SocialType;
+
+public interface AuthService {
+    boolean checkRegisteredTeamOAuthInfo(String clientId, String redirectUri);
+
+    String getSocialUserInfo(SocialType type, String code);
+
+    Long getUserId(SocialType socialType, String userSocialId);
+
+    String generatePlatformCode(Long userId);
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthService.java
@@ -9,5 +9,5 @@ public interface AuthService {
 
     Long getUserId(SocialType socialType, String userSocialId);
 
-    String generatePlatformCode(Long userId);
+    String generatePlatformCode(String clientId, String redirectUri, Long userId);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthServiceImpl.java
@@ -24,10 +24,10 @@ import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_FO
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
     private final SocialLoginManager socialLoginManager;
     private final TeamOAuthInfoRepository teamOAuthInfoRepository;
     private final UserIdentityInfoRepository userIdentityInfoRepository;
-
     private final ValueConfig valueConfig;
 
     @Override

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthServiceImpl.java
@@ -1,0 +1,67 @@
+package org.sopt.makers.operation.auth.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.xml.bind.DatatypeConverter;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.makers.operation.auth.repository.TeamOAuthInfoRepository;
+import org.sopt.makers.operation.client.social.SocialLoginManager;
+import org.sopt.makers.operation.config.ValueConfig;
+import org.sopt.makers.operation.exception.AuthException;
+import org.sopt.makers.operation.user.domain.SocialType;
+import org.sopt.makers.operation.user.repository.identityinfo.UserIdentityInfoRepository;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.time.ZoneId;
+import java.util.Date;
+
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.INVALID_SOCIAL_CODE;
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_FOUND_USER_SOCIAL_IDENTITY_INFO;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private final SocialLoginManager socialLoginManager;
+    private final TeamOAuthInfoRepository teamOAuthInfoRepository;
+    private final UserIdentityInfoRepository userIdentityInfoRepository;
+
+    private final ValueConfig valueConfig;
+
+    @Override
+    public boolean checkRegisteredTeamOAuthInfo(String clientId, String redirectUri) {
+        return teamOAuthInfoRepository.existsByClientIdAndRedirectUri(clientId, redirectUri);
+    }
+
+    @Override
+    public String getSocialUserInfo(SocialType type, String code) {
+        val idToken = socialLoginManager.getIdTokenByCode(type, code);
+        if (idToken == null) throw new AuthException(INVALID_SOCIAL_CODE);
+        return socialLoginManager.getUserInfo(idToken);
+    }
+
+    @Override
+    public Long getUserId(SocialType socialType, String userSocialId) {
+        val userIdentityInfo = userIdentityInfoRepository.findBySocialTypeAndSocialId(socialType, userSocialId)
+                .orElseThrow(() -> new AuthException(NOT_FOUND_USER_SOCIAL_IDENTITY_INFO));
+        return userIdentityInfo.getUserId();
+    }
+
+    @Override
+    public String generatePlatformCode(Long userId) {
+        val platformCodeSecretKey = valueConfig.getPlatformCodeSecretKey();
+
+        val signatureAlgorithm = SignatureAlgorithm.HS256;
+        val secretKeyBytes = DatatypeConverter.parseBase64Binary(platformCodeSecretKey);
+        val signingKey = new SecretKeySpec(secretKeyBytes, signatureAlgorithm.getJcaName());
+        val exp = new Date().toInstant().atZone(KST)
+                .toLocalDateTime().plusMinutes(5).atZone(KST).toInstant();
+        return Jwts.builder()
+                .setSubject(Long.toString(userId))
+                .setExpiration(Date.from(exp))
+                .signWith(signingKey, signatureAlgorithm)
+                .compact();
+    }
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthServiceImpl.java
@@ -23,6 +23,7 @@ import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_FO
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
+
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final SocialLoginManager socialLoginManager;
@@ -38,7 +39,9 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public String getSocialUserInfo(SocialType type, String code) {
         val idToken = socialLoginManager.getIdTokenByCode(type, code);
-        if (idToken == null) throw new AuthException(INVALID_SOCIAL_CODE);
+        if (idToken == null) {
+            throw new AuthException(INVALID_SOCIAL_CODE);
+        }
         return socialLoginManager.getUserInfo(idToken);
     }
 

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthServiceImpl.java
@@ -50,7 +50,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public String generatePlatformCode(Long userId) {
+    public String generatePlatformCode(String clientId, String redirectUri, Long userId) {
         val platformCodeSecretKey = valueConfig.getPlatformCodeSecretKey();
 
         val signatureAlgorithm = SignatureAlgorithm.HS256;
@@ -59,6 +59,8 @@ public class AuthServiceImpl implements AuthService {
         val exp = new Date().toInstant().atZone(KST)
                 .toLocalDateTime().plusMinutes(5).atZone(KST).toInstant();
         return Jwts.builder()
+                .setIssuer(clientId)
+                .setAudience(redirectUri)
                 .setSubject(Long.toString(userId))
                 .setExpiration(Date.from(exp))
                 .signWith(signingKey, signatureAlgorithm)

--- a/operation-api/src/main/java/org/sopt/makers/operation/common/handler/ErrorHandler.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/handler/ErrorHandler.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.operation.common.handler;
 
 import org.sopt.makers.operation.dto.BaseResponse;
+import org.sopt.makers.operation.exception.AuthException;
 import org.sopt.makers.operation.util.ApiResponseUtil;
 import org.sopt.makers.operation.exception.AdminFailureException;
 import org.sopt.makers.operation.exception.AlarmException;
@@ -70,6 +71,12 @@ public class ErrorHandler {
 
     @ExceptionHandler(AttendanceException.class)
     public ResponseEntity<BaseResponse<?>> attendanceException(AttendanceException ex) {
+        log.error(ex.getMessage());
+        return ApiResponseUtil.failure(ex.getFailureCode());
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<BaseResponse<?>> authException(AuthException ex) {
         log.error(ex.getMessage());
         return ApiResponseUtil.failure(ex.getFailureCode());
     }

--- a/operation-api/src/test/java/org/sopt/makers/operation/auth/api/AuthApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/auth/api/AuthApiControllerTest.java
@@ -1,0 +1,130 @@
+package org.sopt.makers.operation.auth.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.val;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.sopt.makers.operation.auth.service.AuthService;
+import org.sopt.makers.operation.common.handler.ErrorHandler;
+import org.sopt.makers.operation.user.domain.SocialType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ContextConfiguration(classes = AuthApiController.class)
+@WebMvcTest(controllers = {AuthApiController.class}, excludeAutoConfiguration = {SecurityAutoConfiguration.class})
+@Import({AuthApiController.class, ErrorHandler.class})
+class AuthApiControllerTest {
+    @MockBean
+    AuthService authService;
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    final String uri = "/api/v1/authorize";
+
+    @Nested
+    @DisplayName("API 통신 성공 테스트")
+    class SuccessTest {
+        @DisplayName("유효한 type, code, clientId, redirectUri 값이 들어왔을 때, 플랫폼 인가코드를 반환한다.")
+        @ParameterizedTest
+        @CsvSource({
+                "APPLE,code,clientId,redirectUri"
+        })
+        void successTest(String type, String code, String clientId, String redirectUri) throws Exception {
+            // given
+            given(authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)).willReturn(true);
+            val socialType = SocialType.valueOf(type);
+            given(authService.getSocialUserInfo(socialType, code)).willReturn("123");
+            given(authService.getUserId(socialType, "123")).willReturn(1L);
+            given(authService.generatePlatformCode(clientId, redirectUri, 1L)).willReturn("Platform Code");
+
+            // when, then
+            mockMvc.perform(get(uri)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .param("type", type)
+                            .param("code", code)
+                            .param("clientId", clientId)
+                            .param("redirectUri", redirectUri))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("플랫폼 인가코드 발급 성공"));
+        }
+    }
+
+    @Nested
+    @DisplayName("쿼리 파라미터 유효성 검사 테스트")
+    class QueryParameterValidateTest {
+
+        @DisplayName("type, code, clientId, redirectUri 중 하나라도 null 이 들어오면 400을 반환한다.")
+        @ParameterizedTest
+        @CsvSource({
+                ",code,clientId,redirectUri",
+                "type,,clientId,redirectUri",
+                "type,code,,redirectUri",
+                "type,code,clientId,"
+        })
+        void validateTest(String type, String code, String clientId, String redirectUri) throws Exception {
+            // when, then
+            mockMvc.perform(get(uri)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .param("type", type)
+                            .param("code", code)
+                            .param("clientId", clientId)
+                            .param("redirectUri", redirectUri))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @DisplayName("등록되지 않은 clientId, redirectUri 라면 404를 반환한다.")
+        @ParameterizedTest
+        @CsvSource({
+                "type,code,clientId,redirectUri"
+        })
+        void validateTest2(String type, String code, String clientId, String redirectUri) throws Exception {
+            // given
+            given(authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)).willReturn(false);
+
+            // when, then
+            mockMvc.perform(get(uri)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .param("type", type)
+                            .param("code", code)
+                            .param("clientId", clientId)
+                            .param("redirectUri", redirectUri))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value("등록되지 않은 팀입니다."));
+            ;
+        }
+
+        @DisplayName("등록되지 않은 social type 이라면 400을 반환한다.")
+        @ParameterizedTest
+        @CsvSource({
+                "KAKAO,code,clientId,redirectUri"
+        })
+        void validateTest3(String type, String code, String clientId, String redirectUri) throws Exception {
+            // given
+            given(authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)).willReturn(true);
+
+            // when, then
+            mockMvc.perform(get(uri)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .param("type", type)
+                            .param("code", code)
+                            .param("clientId", clientId)
+                            .param("redirectUri", redirectUri))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("유효하지 않은 social type 입니다."));
+        }
+    }
+}

--- a/operation-api/src/test/java/org/sopt/makers/operation/auth/service/AuthServiceTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/auth/service/AuthServiceTest.java
@@ -1,0 +1,114 @@
+package org.sopt.makers.operation.auth.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.xml.bind.DatatypeConverter;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.makers.operation.auth.repository.TeamOAuthInfoRepository;
+import org.sopt.makers.operation.client.social.SocialLoginManager;
+import org.sopt.makers.operation.config.ValueConfig;
+import org.sopt.makers.operation.exception.AuthException;
+import org.sopt.makers.operation.user.domain.SocialType;
+import org.sopt.makers.operation.user.repository.identityinfo.UserIdentityInfoRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+    @Mock
+    SocialLoginManager socialLoginManager;
+    @Mock
+    TeamOAuthInfoRepository teamOAuthInfoRepository;
+    @Mock
+    UserIdentityInfoRepository userIdentityInfoRepository;
+    @Mock
+    ValueConfig valueConfig;
+
+    AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthServiceImpl(socialLoginManager, teamOAuthInfoRepository, userIdentityInfoRepository, valueConfig);
+    }
+
+    @Nested
+    @DisplayName("getSocialUserInfo 메서드 테스트")
+    class GetSocialUserInfoMethodTest {
+        @DisplayName("socialLoginManager 으로부터 id token 값을 null 값을 받았다면 AuthException 을 반환한다.")
+        @Test
+        void test() {
+            // given
+            val socialType = SocialType.APPLE;
+            val code = "social code";
+            given(socialLoginManager.getIdTokenByCode(socialType, code)).willReturn(null);
+
+            // when, then
+            assertThatThrownBy(() -> authService.getSocialUserInfo(socialType, code))
+                    .isInstanceOf(AuthException.class)
+                    .hasMessage("[AuthException] : 유효하지 않은 social code 입니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("getUserId 메서드 테스트")
+    class GetUserIdMethodTest {
+        @DisplayName("사전에 등록되지 않은 social type, social id 가 들어왔을 때, AuthException 을 반환한다.")
+        @Test
+        void test() {
+            // given
+            val socialType = SocialType.APPLE;
+            val userSocialId = "user social id";
+            given(userIdentityInfoRepository.findBySocialTypeAndSocialId(socialType, userSocialId)).willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() -> authService.getUserId(socialType, userSocialId))
+                    .isInstanceOf(AuthException.class)
+                    .hasMessage("[AuthException] : 등록된 소셜 정보가 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("generatePlatformCode 메서드 테스트")
+    class GeneratePlatformCodeMethodTest {
+        final String platformSecretKey = "123456789123456789123456789123456789123456789123456789";
+
+        @DisplayName("iss:clientId, aud:redirectUri , sub:userId 인 jwt 토큰을 발급한다.")
+        @Test
+        void test() {
+            // given
+            val clientId = "clientId";
+            val redirectUri = "redirectUri";
+            val userId = 1L;
+            given(valueConfig.getPlatformCodeSecretKey()).willReturn(platformSecretKey);
+
+            // when
+            String platformCode = authService.generatePlatformCode(clientId, redirectUri, userId);
+            Claims claims = getClaimsFromToken(platformCode);
+
+            // then
+            assertThat(claims.getIssuer()).isEqualTo("clientId");
+            assertThat(claims.getAudience()).isEqualTo("redirectUri");
+            assertThat(claims.getSubject()).isEqualTo("1");
+        }
+
+        private Claims getClaimsFromToken(String token) throws SignatureException {
+            return Jwts.parserBuilder()
+                    .setSigningKey(DatatypeConverter.parseBase64Binary(platformSecretKey))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        }
+    }
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/AuthFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/AuthFailureCode.java
@@ -7,20 +7,18 @@ import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Getter
 @RequiredArgsConstructor
 public enum AuthFailureCode implements FailureCode {
     // 400
-    NOT_NULL_PARAMS(BAD_REQUEST, "존재하지 않는 출석 세션입니다."),
-    INVALID_SOCIAL_TYPE(BAD_REQUEST, "유효하지 않는 type 입니다."),
-    INVALID_ID_TOKEN(BAD_REQUEST, "잘못된 토큰이 전달되었습니다."),
-    INVALID_SOCIAL_CODE(BAD_REQUEST, "코드가 유효하지 않습니다."),
+    NOT_NULL_PARAMS(BAD_REQUEST, "쿼리 파라미터 중 데이터가 들어오지 않았습니다."),
+    INVALID_SOCIAL_TYPE(BAD_REQUEST, "유효하지 않은 social type 입니다."),
+    INVALID_ID_TOKEN(BAD_REQUEST, "유효하지 않은 id token 입니다."),
+    INVALID_SOCIAL_CODE(BAD_REQUEST, "유효하지 않은 social code 입니다."),
     FAILURE_READ_PRIVATE_KEY(BAD_REQUEST, "Private key 읽기 실패"),
-    // 401
-    UNREGISTERED_TEAM(UNAUTHORIZED, "등록되지 않은 팀입니다."),
     // 404
+    NOT_FOUNT_REGISTERED_TEAM(NOT_FOUND, "등록되지 않은 팀입니다."),
     NOT_FOUND_USER_SOCIAL_IDENTITY_INFO(NOT_FOUND, "등록된 소셜 정보가 없습니다."),
     ;
 

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/AuthFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/AuthFailureCode.java
@@ -1,0 +1,29 @@
+package org.sopt.makers.operation.code.failure.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.operation.code.failure.FailureCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthFailureCode implements FailureCode {
+    // 400
+    NOT_NULL_PARAMS(BAD_REQUEST, "존재하지 않는 출석 세션입니다."),
+    INVALID_SOCIAL_TYPE(BAD_REQUEST, "유효하지 않는 type 입니다."),
+    INVALID_ID_TOKEN(BAD_REQUEST, "잘못된 토큰이 전달되었습니다."),
+    INVALID_SOCIAL_CODE(BAD_REQUEST, "코드가 유효하지 않습니다."),
+    FAILURE_READ_PRIVATE_KEY(BAD_REQUEST, "Private key 읽기 실패"),
+    // 401
+    UNREGISTERED_TEAM(UNAUTHORIZED, "등록되지 않은 팀입니다."),
+    // 404
+    NOT_FOUND_USER_SOCIAL_IDENTITY_INFO(NOT_FOUND, "등록된 소셜 정보가 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/success/auth/AuthSuccessCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/success/auth/AuthSuccessCode.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.operation.code.success.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.operation.code.success.SuccessCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthSuccessCode implements SuccessCode {
+    SUCCESS_GET_AUTHORIZATION_CODE(OK, "플랫폼 인가코드 발급 성공");
+    private final HttpStatus status;
+    private final String message;
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
@@ -36,6 +36,20 @@ public class ValueConfig {
 	private String playGroundURI;
 	@Value("${sopt.makers.playground.token}")
 	private String playGroundToken;
+	@Value("${oauth.apple.key.id}")
+	private String appleKeyId;
+	@Value("${oauth.apple.team.id}")
+	private String appleTeamId;
+	@Value("${oauth.apple.aud}")
+	private String appleAud;
+	@Value("${oauth.apple.sub}")
+	private String appleSub;
+	@Value("${oauth.google.client.id}")
+	private String googleClientId;
+	@Value("${oauth.google.client.secret}")
+	private String googleClientSecret;
+	@Value("${oauth.google.redirect.url}")
+	private String googleRedirectUrl;
 
 	private final int SUB_LECTURE_MAX_ROUND = 2;
 	private final int MAX_LECTURE_COUNT = 2;

--- a/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
@@ -38,6 +38,8 @@ public class ValueConfig {
 	private String playGroundToken;
 	@Value("${oauth.apple.key.id}")
 	private String appleKeyId;
+	@Value("${oauth.apple.key.path}")
+	private String appleKeyPath;
 	@Value("${oauth.apple.team.id}")
 	private String appleTeamId;
 	@Value("${oauth.apple.aud}")

--- a/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
@@ -50,6 +50,8 @@ public class ValueConfig {
 	private String googleClientSecret;
 	@Value("${oauth.google.redirect.url}")
 	private String googleRedirectUrl;
+	@Value("${spring.jwt.secretKey.platform_code}")
+	private String platformCodeSecretKey;
 
 	private final int SUB_LECTURE_MAX_ROUND = 2;
 	private final int MAX_LECTURE_COUNT = 2;

--- a/operation-common/src/main/java/org/sopt/makers/operation/exception/AuthException.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/exception/AuthException.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.operation.exception;
+
+import lombok.Getter;
+import org.sopt.makers.operation.code.failure.FailureCode;
+
+@Getter
+public class AuthException extends RuntimeException{
+    private final FailureCode failureCode;
+
+    public AuthException(FailureCode failureCode) {
+        super("[AuthException] : " + failureCode.getMessage());
+        this.failureCode = failureCode;
+    }
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/auth/domain/Team.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/auth/domain/Team.java
@@ -1,0 +1,5 @@
+package org.sopt.makers.operation.auth.domain;
+
+public enum Team {
+    PLAYGROUND, CREW, APP
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/auth/domain/TeamOAuthInfo.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/auth/domain/TeamOAuthInfo.java
@@ -11,13 +11,17 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
 public class TeamOAuthInfo {
+
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
+
     @Column(name = "client_id", nullable = false)
     private String clientId;
+
     @Column(name = "redirect_uri", nullable = false)
     private String redirectUri;
+
     @Column(name = "team", nullable = false)
     @Enumerated(EnumType.STRING)
     private Team team;

--- a/operation-domain/src/main/java/org/sopt/makers/operation/auth/domain/TeamOAuthInfo.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/auth/domain/TeamOAuthInfo.java
@@ -1,0 +1,24 @@
+package org.sopt.makers.operation.auth.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+public class TeamOAuthInfo {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    @Column(name = "client_id", nullable = false)
+    private String clientId;
+    @Column(name = "redirect_uri", nullable = false)
+    private String redirectUri;
+    @Column(name = "team", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Team team;
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/auth/repository/TeamOAuthInfoRepository.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/auth/repository/TeamOAuthInfoRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.operation.auth.repository;
+
+import org.sopt.makers.operation.auth.domain.TeamOAuthInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamOAuthInfoRepository extends JpaRepository<TeamOAuthInfo, Long> {
+    boolean existsByClientIdAndRedirectUri(String clientId, String redirectUri);
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/SocialType.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/SocialType.java
@@ -1,6 +1,15 @@
 package org.sopt.makers.operation.user.domain;
 
+import java.util.Arrays;
+
 public enum SocialType {
     GOOGLE,
-    APPLE,
+    APPLE;
+
+
+    public static boolean isContains(String type) {
+        SocialType[] socialTypes = SocialType.values();
+        return Arrays.stream(socialTypes)
+                .anyMatch(socialType -> socialType.name().equals(type));
+    }
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/SocialType.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/SocialType.java
@@ -8,8 +8,7 @@ public enum SocialType {
 
 
     public static boolean isContains(String type) {
-        SocialType[] socialTypes = SocialType.values();
-        return Arrays.stream(socialTypes)
+        return Arrays.stream(SocialType.values())
                 .anyMatch(socialType -> socialType.name().equals(type));
     }
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/identityinfo/UserIdentityInfoRepository.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/identityinfo/UserIdentityInfoRepository.java
@@ -1,0 +1,11 @@
+package org.sopt.makers.operation.user.repository.identityinfo;
+
+import org.sopt.makers.operation.user.domain.SocialType;
+import org.sopt.makers.operation.user.domain.UserIdentityInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserIdentityInfoRepository extends JpaRepository<UserIdentityInfo, Long> {
+    Optional<UserIdentityInfo> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+}

--- a/operation-external/build.gradle
+++ b/operation-external/build.gradle
@@ -11,6 +11,16 @@ dependencies {
     implementation project(path: ':operation-domain')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.75'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.75'
+
+    // jwt builder library
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    runtimeOnly "io.jsonwebtoken:jjwt-impl:0.11.2"
+    runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.11.2"
+    // jwt payload read library
+    implementation "com.nimbusds:nimbus-jose-jwt:7.8.1"
 }
 
 test {

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/social/AppleSocialLogin.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/social/AppleSocialLogin.java
@@ -1,0 +1,93 @@
+package org.sopt.makers.operation.client.social;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.sopt.makers.operation.client.social.dto.IdTokenResponse;
+import org.sopt.makers.operation.config.ValueConfig;
+import org.sopt.makers.operation.exception.AuthException;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.FAILURE_READ_PRIVATE_KEY;
+
+@Component
+@RequiredArgsConstructor
+public class AppleSocialLogin {
+    private final RestTemplate restTemplate;
+    private final ValueConfig valueConfig;
+
+    public IdTokenResponse getIdTokenByCode(String code) {
+        val tokenRequest = new LinkedMultiValueMap<>();
+        val grantType = "authorization_code";
+        val clientId = valueConfig.getAppleSub();
+        val clientSecret = createClientSecret();
+
+        tokenRequest.add("client_id", clientId);
+        tokenRequest.add("client_secret", clientSecret);
+        tokenRequest.add("code", code);
+        tokenRequest.add("grant_type", grantType);
+
+        val headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        val entity = new HttpEntity<>(tokenRequest, headers);
+
+        val host = "https://appleid.apple.com/auth/token";
+        return restTemplate.postForObject(host, entity, IdTokenResponse.class);
+    }
+
+    private String createClientSecret() {
+        val now = new Date();
+        val privateKey = getPrivateKey()
+                .orElseThrow(() -> new AuthException(FAILURE_READ_PRIVATE_KEY));
+        val kid = valueConfig.getAppleKeyId();
+        val issuer = valueConfig.getAppleTeamId();
+        val aud = valueConfig.getAppleAud();
+        val sub = valueConfig.getAppleSub();
+
+        return Jwts.builder()
+                .setHeaderParam("kid", kid)
+                .setHeaderParam("alg", "ES256")
+                .setIssuedAt(now)
+                .setExpiration(new Date(System.currentTimeMillis() + 3600 * 1000))
+                .setIssuer(issuer)
+                .setAudience(aud)
+                .setSubject(sub)
+                .signWith(privateKey, SignatureAlgorithm.ES256)
+                .compact();
+    }
+
+    private Optional<PrivateKey> getPrivateKey() {
+        val appleKeyPath = "authConfig.getAppleKeyPath()";
+        try {
+            val resource = new ClassPathResource(appleKeyPath);
+            val privateKey = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            val pemReader = new StringReader(privateKey);
+            val pemParser = new PEMParser(pemReader);
+            val converter = new JcaPEMKeyConverter();
+            val object = (PrivateKeyInfo) pemParser.readObject();
+            return Optional.of(converter.getPrivateKey(object));
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/social/GoogleSocialLogin.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/social/GoogleSocialLogin.java
@@ -1,0 +1,43 @@
+package org.sopt.makers.operation.client.social;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.makers.operation.client.social.dto.IdTokenResponse;
+import org.sopt.makers.operation.config.ValueConfig;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleSocialLogin {
+    private final RestTemplate restTemplate;
+    private final ValueConfig valueConfig;
+
+    public IdTokenResponse getIdTokenByCode(String code) {
+        val params = new LinkedMultiValueMap<>();
+        val grantType = "authorization_code";
+        val clientId = valueConfig.getGoogleClientId();
+        val clientSecret = valueConfig.getGoogleClientSecret();
+        val redirectUri = valueConfig.getGoogleRedirectUrl();
+
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("code", code);
+        params.add("grant_type", grantType);
+        params.add("redirect_uri", redirectUri);
+
+        val headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        val entity = new HttpEntity<>(params, headers);
+
+        val host = "https://oauth2.googleapis.com/token";
+        return restTemplate.postForObject(host, entity, IdTokenResponse.class);
+    }
+}

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/social/GoogleSocialLogin.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/social/GoogleSocialLogin.java
@@ -16,12 +16,14 @@ import java.util.Collections;
 @Component
 @RequiredArgsConstructor
 public class GoogleSocialLogin {
+    private static final String GRANT_TYPE = "authorization_code";
+    private static final String HOST = "https://oauth2.googleapis.com/token";
+
     private final RestTemplate restTemplate;
     private final ValueConfig valueConfig;
 
     public IdTokenResponse getIdTokenByCode(String code) {
         val params = new LinkedMultiValueMap<>();
-        val grantType = "authorization_code";
         val clientId = valueConfig.getGoogleClientId();
         val clientSecret = valueConfig.getGoogleClientSecret();
         val redirectUri = valueConfig.getGoogleRedirectUrl();
@@ -29,7 +31,7 @@ public class GoogleSocialLogin {
         params.add("client_id", clientId);
         params.add("client_secret", clientSecret);
         params.add("code", code);
-        params.add("grant_type", grantType);
+        params.add("grant_type", GRANT_TYPE);
         params.add("redirect_uri", redirectUri);
 
         val headers = new HttpHeaders();
@@ -37,7 +39,6 @@ public class GoogleSocialLogin {
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         val entity = new HttpEntity<>(params, headers);
 
-        val host = "https://oauth2.googleapis.com/token";
-        return restTemplate.postForObject(host, entity, IdTokenResponse.class);
+        return restTemplate.postForObject(HOST, entity, IdTokenResponse.class);
     }
 }

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/social/SocialLoginManager.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/social/SocialLoginManager.java
@@ -1,0 +1,39 @@
+package org.sopt.makers.operation.client.social;
+
+import com.nimbusds.jwt.SignedJWT;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.makers.operation.client.social.dto.IdTokenResponse;
+import org.sopt.makers.operation.exception.AuthException;
+import org.sopt.makers.operation.user.domain.SocialType;
+import org.springframework.stereotype.Component;
+
+import java.text.ParseException;
+
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.INVALID_ID_TOKEN;
+
+@Component
+@RequiredArgsConstructor
+public class SocialLoginManager {
+    private final AppleSocialLogin appleSocialLogin;
+    private final GoogleSocialLogin googleSocialLogin;
+
+    public IdTokenResponse getIdTokenByCode(SocialType type, String code) {
+        return switch (type) {
+            case APPLE -> appleSocialLogin.getIdTokenByCode(code);
+            case GOOGLE -> googleSocialLogin.getIdTokenByCode(code);
+        };
+    }
+
+    public String getUserInfo(IdTokenResponse tokenResponse) {
+        val idToken = tokenResponse.idToken();
+        try {
+            val signedJWT = SignedJWT.parse(idToken);
+            val payload = signedJWT.getJWTClaimsSet();
+            val userId = payload.getSubject();
+            return userId;
+        } catch (ParseException e) {
+            throw new AuthException(INVALID_ID_TOKEN);
+        }
+    }
+}

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/social/dto/IdTokenResponse.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/social/dto/IdTokenResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.operation.client.social.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record IdTokenResponse(
+        @JsonProperty("id_token")
+        String idToken
+) {
+}


### PR DESCRIPTION
## Related Issue 🚀
- closed #258 

## Work Description ✏️
1. external 모듈 내 소셜 로그인 기능 구현

## PR Point 📸
1. Auth Controller 내부에서 Social Login Manger를 이용하여 소셜 로그인을 진행하려 합니다.
    추상화를 통해 공통된 로직을 분리하려 했으나, 해당 방식은 확장성을 방해한다고 생각하여
    소셜 로그인 별로 class 를 만들었습니다.
    [ex. 소셜 로그인 변경 or 소셜 로그인 중 open id 방식을 지원하지 않을 수 있음 ]

2. 비즈니스 로직
    [c826462](https://github.com/sopt-makers/sopt-operation-backend/pull/260/commits/c8264627d1f381d459d7413d114e64e024e1c0f0) 해당 커밋 메시지처럼 구현했습니다..!

3. 플랫폼 인가 코드 저장을 위한 concurrent hash map
    redis를 아직 사용하지 않기 때문에 concurrent hash map 내부에 인가코드를 저장했습니다.
    해당 map은 플랫폼 인가 코드를 단 1회만 사용할 수 있도록 만들기 위해서 인가 코드를 잠시 저장하는 용도입니다.
    `/token` API 시 인가 코드가 MAP에 있는지 확인 후, 해당 인가 코드를 제거할 것입니다.
    
4. 에러 메시지 및 함수 명 작성이 명시적인지 궁금합니다.