### PR TITLE
#261_T-10856 [feat] /token API 구현

### DIFF
--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApi.java
@@ -3,6 +3,7 @@ package org.sopt.makers.operation.auth.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.sopt.makers.operation.auth.dto.request.AccessTokenRequest;
 import org.sopt.makers.operation.dto.BaseResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,4 +46,37 @@ public interface AuthApi {
             @RequestParam String clientId,
             @RequestParam String redirectUri
     );
+
+    @Operation(
+            security = @SecurityRequirement(name = "Authorization"),
+            summary = "인증 토큰 발급 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "토큰 발급 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = """
+                                    1. grantType 데이터가 들어오지 않았습니다.\n
+                                    2. 유효하지 않은 grantType 입니다.\n
+                                    3. 플랫폼 인가코드가 들어오지 않았습니다.\n
+                                    4. 이미 사용한 플랫폼 인가코드입니다.\n
+                                    5. 리프레쉬 토큰이 들어오지 않았습니다.
+                                    """
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = """
+                                    1. 만료된 플랫폼 인가 코드입니다.\n
+                                    2. 만료된 리프레쉬 토큰입니다.
+                                    """
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 내부 오류"
+                    )
+            }
+    )
+    ResponseEntity<BaseResponse<?>> token(AccessTokenRequest accessTokenRequest);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -2,27 +2,44 @@ package org.sopt.makers.operation.auth.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import org.sopt.makers.operation.auth.dto.request.AccessTokenRequest;
 import org.sopt.makers.operation.auth.dto.response.AuthorizationCodeResponse;
+import org.sopt.makers.operation.auth.dto.response.TokenResponse;
 import org.sopt.makers.operation.auth.service.AuthService;
 import org.sopt.makers.operation.dto.BaseResponse;
 import org.sopt.makers.operation.exception.AuthException;
 import org.sopt.makers.operation.jwt.JwtTokenProvider;
 import org.sopt.makers.operation.user.domain.SocialType;
 import org.sopt.makers.operation.util.ApiResponseUtil;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.EXPIRED_PLATFORM_CODE;
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.EXPIRED_REFRESH_TOKEN;
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.INVALID_GRANT_TYPE;
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.INVALID_SOCIAL_TYPE;
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_FOUNT_REGISTERED_TEAM;
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_NULL_CODE;
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_NULL_GRANT_TYPE;
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.USED_PLATFORM_CODE;
+import static org.sopt.makers.operation.code.success.auth.AuthSuccessCode.SUCCESS_GENERATE_TOKEN;
 import static org.sopt.makers.operation.code.success.auth.AuthSuccessCode.SUCCESS_GET_AUTHORIZATION_CODE;
+import static org.sopt.makers.operation.jwt.JwtTokenType.PLATFORM_CODE;
+import static org.sopt.makers.operation.jwt.JwtTokenType.REFRESH_TOKEN;
 
 @RestController
 @RequiredArgsConstructor
 public class AuthApiController implements AuthApi {
+
+    private static final String AUTHORIZATION_CODE_GRANT_TYPE = "authorizationCode";
+    private static final String REFRESH_TOKEN_GRANT_TYPE = "refreshToken";
 
     private final ConcurrentHashMap<String, String> tempPlatformCode;
     private final AuthService authService;
@@ -46,6 +63,60 @@ public class AuthApiController implements AuthApi {
         val userId = findUserIdBySocialTypeAndCode(type, code);
         val platformCode = generatePlatformCode(clientId, redirectUri, userId);
         return ApiResponseUtil.success(SUCCESS_GET_AUTHORIZATION_CODE, new AuthorizationCodeResponse(platformCode));
+    }
+
+    @Override
+    @PostMapping(
+            path = "/api/v1/token",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
+    )
+    public ResponseEntity<BaseResponse<?>> token(AccessTokenRequest accessTokenRequest) {
+        if (accessTokenRequest.isNullGrantType()) {
+            throw new AuthException(NOT_NULL_GRANT_TYPE);
+        }
+
+        val grantType = accessTokenRequest.grantType();
+        if (!(grantType.equals(AUTHORIZATION_CODE_GRANT_TYPE) || grantType.equals(REFRESH_TOKEN_GRANT_TYPE))) {
+            throw new AuthException(INVALID_GRANT_TYPE);
+        }
+
+        val tokenResponse = grantType.equals(AUTHORIZATION_CODE_GRANT_TYPE) ?
+                generateTokenResponseByAuthorizationCode(accessTokenRequest) : generateTokenResponseByRefreshToken(accessTokenRequest);
+        return ApiResponseUtil.success(SUCCESS_GENERATE_TOKEN, tokenResponse);
+    }
+
+    private TokenResponse generateTokenResponseByAuthorizationCode(AccessTokenRequest accessTokenRequest) {
+        if (accessTokenRequest.isNullCode()) {
+            throw new AuthException(NOT_NULL_CODE);
+        }
+        if (!tempPlatformCode.contains(accessTokenRequest.code())) {
+            throw new AuthException(USED_PLATFORM_CODE);
+        }
+        if (!jwtTokenProvider.validatePlatformCode(accessTokenRequest.code(), accessTokenRequest.clientId(), accessTokenRequest.redirectUri())) {
+            throw new AuthException(EXPIRED_PLATFORM_CODE);
+        }
+
+        val authentication = jwtTokenProvider.getAuthentication(accessTokenRequest.code(), PLATFORM_CODE);
+        tempPlatformCode.remove(accessTokenRequest.code());
+        return generateTokenResponse(authentication);
+    }
+
+    private TokenResponse generateTokenResponseByRefreshToken(AccessTokenRequest accessTokenRequest) {
+        if (accessTokenRequest.isNullRefreshToken()) {
+            throw new AuthException(USED_PLATFORM_CODE);
+        }
+        if (!jwtTokenProvider.validateTokenExpiration(accessTokenRequest.refreshToken(), REFRESH_TOKEN)) {
+            throw new AuthException(EXPIRED_REFRESH_TOKEN);
+        }
+
+        val authentication = jwtTokenProvider.getAuthentication(accessTokenRequest.refreshToken(), REFRESH_TOKEN);
+        return generateTokenResponse(authentication);
+    }
+
+    private TokenResponse generateTokenResponse(Authentication authentication) {
+        val accessToken = jwtTokenProvider.generateAccessToken(authentication);
+        val refreshToken = jwtTokenProvider.generateRefreshToken(authentication);
+        return TokenResponse.of(accessToken, refreshToken);
     }
 
     private Long findUserIdBySocialTypeAndCode(String type, String code) {

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -24,7 +24,7 @@ import static org.sopt.makers.operation.code.success.auth.AuthSuccessCode.SUCCES
 @RequiredArgsConstructor
 public class AuthApiController implements AuthApi {
 
-    private final ConcurrentHashMap<String, String> tempPlatformCode = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> tempPlatformCode;
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -28,6 +28,7 @@ import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.INVALI
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_FOUNT_REGISTERED_TEAM;
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_NULL_CODE;
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_NULL_GRANT_TYPE;
+import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_NULL_REFRESH_TOKEN;
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.USED_PLATFORM_CODE;
 import static org.sopt.makers.operation.code.success.auth.AuthSuccessCode.SUCCESS_GENERATE_TOKEN;
 import static org.sopt.makers.operation.code.success.auth.AuthSuccessCode.SUCCESS_GET_AUTHORIZATION_CODE;
@@ -103,7 +104,7 @@ public class AuthApiController implements AuthApi {
 
     private TokenResponse generateTokenResponseByRefreshToken(AccessTokenRequest accessTokenRequest) {
         if (accessTokenRequest.isNullRefreshToken()) {
-            throw new AuthException(USED_PLATFORM_CODE);
+            throw new AuthException(NOT_NULL_REFRESH_TOKEN);
         }
         if (!jwtTokenProvider.validateTokenExpiration(accessTokenRequest.refreshToken(), REFRESH_TOKEN)) {
             throw new AuthException(EXPIRED_REFRESH_TOKEN);

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -6,6 +6,7 @@ import org.sopt.makers.operation.auth.dto.response.AuthorizationCodeResponse;
 import org.sopt.makers.operation.auth.service.AuthService;
 import org.sopt.makers.operation.dto.BaseResponse;
 import org.sopt.makers.operation.exception.AuthException;
+import org.sopt.makers.operation.jwt.JwtTokenProvider;
 import org.sopt.makers.operation.user.domain.SocialType;
 import org.sopt.makers.operation.util.ApiResponseUtil;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,7 @@ public class AuthApiController implements AuthApi {
 
     private final ConcurrentHashMap<String, String> tempPlatformCode = new ConcurrentHashMap<>();
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     @GetMapping("/api/v1/authorize")
@@ -53,7 +55,7 @@ public class AuthApiController implements AuthApi {
     }
 
     private String generatePlatformCode(String clientId, String redirectUri, Long userId) {
-        val platformCode = authService.generatePlatformCode(clientId, redirectUri, userId);
+        val platformCode = jwtTokenProvider.generatePlatformCode(clientId, redirectUri, userId);
         tempPlatformCode.putIfAbsent(platformCode, platformCode);
         return platformCode;
     }

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -93,12 +93,13 @@ public class AuthApiController implements AuthApi {
         if (!tempPlatformCode.contains(accessTokenRequest.code())) {
             throw new AuthException(USED_PLATFORM_CODE);
         }
+        tempPlatformCode.remove(accessTokenRequest.code());
+
         if (!jwtTokenProvider.validatePlatformCode(accessTokenRequest.code(), accessTokenRequest.clientId(), accessTokenRequest.redirectUri())) {
             throw new AuthException(EXPIRED_PLATFORM_CODE);
         }
 
         val authentication = jwtTokenProvider.getAuthentication(accessTokenRequest.code(), PLATFORM_CODE);
-        tempPlatformCode.remove(accessTokenRequest.code());
         return generateTokenResponse(authentication);
     }
 

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/dto/request/AccessTokenRequest.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/dto/request/AccessTokenRequest.java
@@ -1,0 +1,21 @@
+package org.sopt.makers.operation.auth.dto.request;
+
+public record AccessTokenRequest(
+        String grantType,
+        String clientId,
+        String redirectUri,
+        String code,
+        String refreshToken
+) {
+    public boolean isNullGrantType() {
+        return grantType == null;
+    }
+
+    public boolean isNullCode() {
+        return code == null;
+    }
+
+    public boolean isNullRefreshToken() {
+        return refreshToken == null;
+    }
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/dto/response/TokenResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/dto/response/TokenResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.operation.auth.dto.response;
+
+public record TokenResponse(String tokenType, String accessToken, String refreshToken) {
+    private static final String BEARER_TOKEN_TYPE = "Bearer";
+
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(BEARER_TOKEN_TYPE, accessToken, refreshToken);
+    }
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthService.java
@@ -8,6 +8,4 @@ public interface AuthService {
     String getSocialUserInfo(SocialType type, String code);
 
     Long getUserId(SocialType socialType, String userSocialId);
-
-    String generatePlatformCode(String clientId, String redirectUri, Long userId);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/service/AuthServiceImpl.java
@@ -1,21 +1,13 @@
 package org.sopt.makers.operation.auth.service;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import jakarta.xml.bind.DatatypeConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.makers.operation.auth.repository.TeamOAuthInfoRepository;
 import org.sopt.makers.operation.client.social.SocialLoginManager;
-import org.sopt.makers.operation.config.ValueConfig;
 import org.sopt.makers.operation.exception.AuthException;
 import org.sopt.makers.operation.user.domain.SocialType;
 import org.sopt.makers.operation.user.repository.identityinfo.UserIdentityInfoRepository;
 import org.springframework.stereotype.Service;
-
-import javax.crypto.spec.SecretKeySpec;
-import java.time.ZoneId;
-import java.util.Date;
 
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.INVALID_SOCIAL_CODE;
 import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_FOUND_USER_SOCIAL_IDENTITY_INFO;
@@ -24,12 +16,9 @@ import static org.sopt.makers.operation.code.failure.auth.AuthFailureCode.NOT_FO
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
     private final SocialLoginManager socialLoginManager;
     private final TeamOAuthInfoRepository teamOAuthInfoRepository;
     private final UserIdentityInfoRepository userIdentityInfoRepository;
-    private final ValueConfig valueConfig;
 
     @Override
     public boolean checkRegisteredTeamOAuthInfo(String clientId, String redirectUri) {
@@ -50,23 +39,5 @@ public class AuthServiceImpl implements AuthService {
         val userIdentityInfo = userIdentityInfoRepository.findBySocialTypeAndSocialId(socialType, userSocialId)
                 .orElseThrow(() -> new AuthException(NOT_FOUND_USER_SOCIAL_IDENTITY_INFO));
         return userIdentityInfo.getUserId();
-    }
-
-    @Override
-    public String generatePlatformCode(String clientId, String redirectUri, Long userId) {
-        val platformCodeSecretKey = valueConfig.getPlatformCodeSecretKey();
-
-        val signatureAlgorithm = SignatureAlgorithm.HS256;
-        val secretKeyBytes = DatatypeConverter.parseBase64Binary(platformCodeSecretKey);
-        val signingKey = new SecretKeySpec(secretKeyBytes, signatureAlgorithm.getJcaName());
-        val exp = new Date().toInstant().atZone(KST)
-                .toLocalDateTime().plusMinutes(5).atZone(KST).toInstant();
-        return Jwts.builder()
-                .setIssuer(clientId)
-                .setAudience(redirectUri)
-                .setSubject(Long.toString(userId))
-                .setExpiration(Date.from(exp))
-                .signWith(signingKey, signatureAlgorithm)
-                .compact();
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/common/config/ConcurrentHashMapConfig.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/config/ConcurrentHashMapConfig.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.operation.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration
+public class ConcurrentHashMapConfig {
+    @Bean
+    public ConcurrentHashMap<String, String> registerConcurrentHashMap() {
+        return new ConcurrentHashMap<>();
+    }
+}

--- a/operation-api/src/test/java/org/sopt/makers/operation/auth/api/AuthApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/auth/api/AuthApiControllerTest.java
@@ -130,7 +130,7 @@ class AuthApiControllerTest {
     }
 
     @Nested
-    @DisplayName("쿼리 파라미터 유효성 검사 테스트")
+    @DisplayName("/authorize API 쿼리 파라미터 유효성 검사 테스트")
     class QueryParameterValidateTest {
 
         @DisplayName("type, code, clientId, redirectUri 중 하나라도 null 이 들어오면 400을 반환한다.")

--- a/operation-api/src/test/java/org/sopt/makers/operation/auth/api/AuthApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/auth/api/AuthApiControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.sopt.makers.operation.auth.service.AuthService;
 import org.sopt.makers.operation.common.handler.ErrorHandler;
+import org.sopt.makers.operation.jwt.JwtTokenProvider;
 import org.sopt.makers.operation.user.domain.SocialType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -29,6 +30,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class AuthApiControllerTest {
     @MockBean
     AuthService authService;
+    @MockBean
+    JwtTokenProvider jwtTokenProvider;
     @Autowired
     MockMvc mockMvc;
     @Autowired
@@ -49,7 +52,7 @@ class AuthApiControllerTest {
             val socialType = SocialType.valueOf(type);
             given(authService.getSocialUserInfo(socialType, code)).willReturn("123");
             given(authService.getUserId(socialType, "123")).willReturn(1L);
-            given(authService.generatePlatformCode(clientId, redirectUri, 1L)).willReturn("Platform Code");
+            given(jwtTokenProvider.generatePlatformCode(clientId, redirectUri, 1L)).willReturn("Platform Code");
 
             // when, then
             mockMvc.perform(get(uri)

--- a/operation-api/src/test/java/org/sopt/makers/operation/auth/api/AuthApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/auth/api/AuthApiControllerTest.java
@@ -19,6 +19,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -32,11 +34,13 @@ class AuthApiControllerTest {
     AuthService authService;
     @MockBean
     JwtTokenProvider jwtTokenProvider;
+    @MockBean
+    ConcurrentHashMap<String, String> tempPlatformCode;
     @Autowired
     MockMvc mockMvc;
     @Autowired
     ObjectMapper objectMapper;
-    final String uri = "/api/v1/authorize";
+    final String authorizeUri = "/api/v1/authorize";
 
     @Nested
     @DisplayName("API 통신 성공 테스트")
@@ -55,7 +59,7 @@ class AuthApiControllerTest {
             given(jwtTokenProvider.generatePlatformCode(clientId, redirectUri, 1L)).willReturn("Platform Code");
 
             // when, then
-            mockMvc.perform(get(uri)
+            mockMvc.perform(get(authorizeUri)
                             .contentType(MediaType.APPLICATION_JSON)
                             .param("type", type)
                             .param("code", code)
@@ -80,7 +84,7 @@ class AuthApiControllerTest {
         })
         void validateTest(String type, String code, String clientId, String redirectUri) throws Exception {
             // when, then
-            mockMvc.perform(get(uri)
+            mockMvc.perform(get(authorizeUri)
                             .contentType(MediaType.APPLICATION_JSON)
                             .param("type", type)
                             .param("code", code)
@@ -99,7 +103,7 @@ class AuthApiControllerTest {
             given(authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)).willReturn(false);
 
             // when, then
-            mockMvc.perform(get(uri)
+            mockMvc.perform(get(authorizeUri)
                             .contentType(MediaType.APPLICATION_JSON)
                             .param("type", type)
                             .param("code", code)
@@ -120,7 +124,7 @@ class AuthApiControllerTest {
             given(authService.checkRegisteredTeamOAuthInfo(clientId, redirectUri)).willReturn(true);
 
             // when, then
-            mockMvc.perform(get(uri)
+            mockMvc.perform(get(authorizeUri)
                             .contentType(MediaType.APPLICATION_JSON)
                             .param("type", type)
                             .param("code", code)

--- a/operation-api/src/test/java/org/sopt/makers/operation/auth/service/AuthServiceTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/auth/service/AuthServiceTest.java
@@ -1,9 +1,5 @@
 package org.sopt.makers.operation.auth.service;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.SignatureException;
-import jakarta.xml.bind.DatatypeConverter;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,14 +10,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.makers.operation.auth.repository.TeamOAuthInfoRepository;
 import org.sopt.makers.operation.client.social.SocialLoginManager;
-import org.sopt.makers.operation.config.ValueConfig;
 import org.sopt.makers.operation.exception.AuthException;
 import org.sopt.makers.operation.user.domain.SocialType;
 import org.sopt.makers.operation.user.repository.identityinfo.UserIdentityInfoRepository;
 
 import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
@@ -33,14 +27,12 @@ class AuthServiceTest {
     TeamOAuthInfoRepository teamOAuthInfoRepository;
     @Mock
     UserIdentityInfoRepository userIdentityInfoRepository;
-    @Mock
-    ValueConfig valueConfig;
 
     AuthService authService;
 
     @BeforeEach
     void setUp() {
-        authService = new AuthServiceImpl(socialLoginManager, teamOAuthInfoRepository, userIdentityInfoRepository, valueConfig);
+        authService = new AuthServiceImpl(socialLoginManager, teamOAuthInfoRepository, userIdentityInfoRepository);
     }
 
     @Nested
@@ -79,36 +71,4 @@ class AuthServiceTest {
         }
     }
 
-    @Nested
-    @DisplayName("generatePlatformCode 메서드 테스트")
-    class GeneratePlatformCodeMethodTest {
-        final String platformSecretKey = "123456789123456789123456789123456789123456789123456789";
-
-        @DisplayName("iss:clientId, aud:redirectUri , sub:userId 인 jwt 토큰을 발급한다.")
-        @Test
-        void test() {
-            // given
-            val clientId = "clientId";
-            val redirectUri = "redirectUri";
-            val userId = 1L;
-            given(valueConfig.getPlatformCodeSecretKey()).willReturn(platformSecretKey);
-
-            // when
-            String platformCode = authService.generatePlatformCode(clientId, redirectUri, userId);
-            Claims claims = getClaimsFromToken(platformCode);
-
-            // then
-            assertThat(claims.getIssuer()).isEqualTo("clientId");
-            assertThat(claims.getAudience()).isEqualTo("redirectUri");
-            assertThat(claims.getSubject()).isEqualTo("1");
-        }
-
-        private Claims getClaimsFromToken(String token) throws SignatureException {
-            return Jwts.parserBuilder()
-                    .setSigningKey(DatatypeConverter.parseBase64Binary(platformSecretKey))
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-        }
-    }
 }

--- a/operation-api/src/test/java/org/sopt/makers/operation/jwt/JwtTokenProviderTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,99 @@
+package org.sopt.makers.operation.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class JwtTokenProviderTest {
+    final String platformSecretKey = "123456789123456789123456789123456789123456789123456789";
+    JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProvider("", "", "", platformSecretKey);
+    }
+
+    @Nested
+    @DisplayName("generatePlatformCode 메서드 테스트")
+    class GeneratePlatformCodeMethodTest {
+
+        @DisplayName("iss:clientId, aud:redirectUri , sub:userId 인 jwt 토큰을 발급한다.")
+        @Test
+        void test() {
+            // given
+            val clientId = "clientId";
+            val redirectUri = "redirectUri";
+            val userId = 1L;
+
+            // when
+            String platformCode = jwtTokenProvider.generatePlatformCode(clientId, redirectUri, userId);
+            val claims = getClaimsFromToken(platformCode);
+
+            // then
+            assertThat(claims.getIssuer()).isEqualTo("clientId");
+            assertThat(claims.getAudience()).isEqualTo("redirectUri");
+            assertThat(claims.getSubject()).isEqualTo("1");
+        }
+
+        private Claims getClaimsFromToken(String token) {
+            val encodedKey = encodeKey(platformSecretKey);
+
+            return Jwts.parserBuilder()
+                    .setSigningKey(encodedKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        }
+
+        private String encodeKey(String secretKey) {
+            return Base64.getEncoder().encodeToString(secretKey.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    @Nested
+    @DisplayName("validatePlatformCode 메서드 테스트")
+    class ValidatePlatformCodeMethodTest {
+
+        @DisplayName("iss:clientId, aud:redirectUri , sub:userId 인 jwt 토큰과 clientId, redirectUri 를 아규먼트로 넣으면 true 를 반환한다.")
+        @Test
+        void test() {
+            // given
+            val clientId = "clientId";
+            val redirectUri = "redirectUri";
+            val userId = 1L;
+            String platformCode = jwtTokenProvider.generatePlatformCode(clientId, redirectUri, userId);
+
+            // when
+            val result = jwtTokenProvider.validatePlatformCode(platformCode, "clientId", "redirectUri");
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @DisplayName("iss:clientId, aud:redirectUri , sub:userId 인 jwt 토큰과 notClientId, notRedirectUri 를 아규먼트로 넣으면 false 를 반환한다.")
+        @Test
+        void test2() {
+            // given
+            val clientId = "clientId";
+            val redirectUri = "redirectUri";
+            val userId = 1L;
+            String platformCode = jwtTokenProvider.generatePlatformCode(clientId, redirectUri, userId);
+
+            // when
+            val result = jwtTokenProvider.validatePlatformCode(platformCode, "notClientId", "notRedirectUri");
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+}

--- a/operation-auth/src/main/java/org/sopt/makers/operation/jwt/JwtTokenType.java
+++ b/operation-auth/src/main/java/org/sopt/makers/operation/jwt/JwtTokenType.java
@@ -1,5 +1,5 @@
 package org.sopt.makers.operation.jwt;
 
 public enum JwtTokenType {
-    ACCESS_TOKEN, REFRESH_TOKEN, APP_ACCESS_TOKEN
+    ACCESS_TOKEN, REFRESH_TOKEN, APP_ACCESS_TOKEN, PLATFORM_CODE
 }

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/AuthFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/AuthFailureCode.java
@@ -7,16 +7,24 @@ import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Getter
 @RequiredArgsConstructor
 public enum AuthFailureCode implements FailureCode {
     // 400
-    NOT_NULL_PARAMS(BAD_REQUEST, "쿼리 파라미터 중 데이터가 들어오지 않았습니다."),
+    NOT_NULL_GRANT_TYPE(BAD_REQUEST, "grantType 데이터가 들어오지 않았습니다."),
     INVALID_SOCIAL_TYPE(BAD_REQUEST, "유효하지 않은 social type 입니다."),
     INVALID_ID_TOKEN(BAD_REQUEST, "유효하지 않은 id token 입니다."),
     INVALID_SOCIAL_CODE(BAD_REQUEST, "유효하지 않은 social code 입니다."),
     FAILURE_READ_PRIVATE_KEY(BAD_REQUEST, "Private key 읽기 실패"),
+    INVALID_GRANT_TYPE(BAD_REQUEST, "유효하지 않은 grantType 입니다."),
+    NOT_NULL_CODE(BAD_REQUEST, "플랫폼 인가코드가 들어오지 않았습니다."),
+    USED_PLATFORM_CODE(BAD_REQUEST, "이미 사용한 플랫폼 인가코드입니다."),
+    NOT_NULL_REFRESH_TOKEN(BAD_REQUEST, "리프레쉬 토큰이 들어오지 않았습니다."),
+    // 401
+    EXPIRED_PLATFORM_CODE(UNAUTHORIZED, "만료된 플랫폼 인가 코드입니다."),
+    EXPIRED_REFRESH_TOKEN(UNAUTHORIZED, "만료된 리프레쉬 토큰입니다."),
     // 404
     NOT_FOUNT_REGISTERED_TEAM(NOT_FOUND, "등록되지 않은 팀입니다."),
     NOT_FOUND_USER_SOCIAL_IDENTITY_INFO(NOT_FOUND, "등록된 소셜 정보가 없습니다."),

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/AuthFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/AuthFailureCode.java
@@ -23,7 +23,7 @@ public enum AuthFailureCode implements FailureCode {
     USED_PLATFORM_CODE(BAD_REQUEST, "이미 사용한 플랫폼 인가코드입니다."),
     NOT_NULL_REFRESH_TOKEN(BAD_REQUEST, "리프레쉬 토큰이 들어오지 않았습니다."),
     // 401
-    EXPIRED_PLATFORM_CODE(UNAUTHORIZED, "만료된 플랫폼 인가 코드입니다."),
+    EXPIRED_PLATFORM_CODE(UNAUTHORIZED, "만료된 플랫폼 인가코드입니다."),
     EXPIRED_REFRESH_TOKEN(UNAUTHORIZED, "만료된 리프레쉬 토큰입니다."),
     // 404
     NOT_FOUNT_REGISTERED_TEAM(NOT_FOUND, "등록되지 않은 팀입니다."),

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/success/auth/AuthSuccessCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/success/auth/AuthSuccessCode.java
@@ -10,7 +10,8 @@ import static org.springframework.http.HttpStatus.OK;
 @Getter
 @RequiredArgsConstructor
 public enum AuthSuccessCode implements SuccessCode {
-    SUCCESS_GET_AUTHORIZATION_CODE(OK, "플랫폼 인가코드 발급 성공");
+    SUCCESS_GET_AUTHORIZATION_CODE(OK, "플랫폼 인가코드 발급 성공"),
+    SUCCESS_GENERATE_TOKEN(OK, "토큰 발급 성공");
     private final HttpStatus status;
     private final String message;
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #261 

## Work Description ✏️
- /token api 구현

## PR Point 📸
### 1. jwt token provider 사용

기존에는 auth service 에서 플랫폼 인가코드를 생성하는 로직이 있었습니다.
개발 도중 기존에 만들어진 jwt token provider를 사용하면 코드 중복을 줄일 수 있겠다고 생각하여
Platform Code enum 값을 추가하여 플랫폼 인가코드를 발급하는 로직을 추가했습니다.

### 2. concurrent hash map 빈 등록
/token 테스트 코드를 작성할 때, hash map에 플랫폼 인가코드가 contain하는지 검증하는 로직을 테스트해야 했습니다.
기존에는 `= new Hashmap<>() ` 같이 설정했기 때문에 테스트 코드를 작성하는데 어려웠습니다.
이를 해결하기 위해 **Configuration을 통해 ConcurrentHashMap을 bean으로 등록**해 의존성을 주입받는 형태로 변경했고,
테스트 코드에서는 mockbean을 통해 테스트 가능하도록 만들었습니다.

### 3. refresh token 검증 과정
클라이언트가 ATK가 만료되어 RTK를 통해 토큰을 갱신 받는 과정에서 grantType 과 refreshToken만 받고 있습니다.
clientId와 redirectUri를 claims에 넣어 검증하려 했으나, 
플레이그라운드에서 발급한 토큰이 모임에서 만료되었을 때, **토큰 내부의 clientId와 호출하는 팀(모임)의 clientId가 다르기 때문에** 위와 같은 검증이 제대로 이뤄지지 않을 것이라 판단했습니다.

따라서 grantType 과 refreshToken만 받아서 refreshToken이 만료되지 않았다면 다시 ATK, RTK를 반환하도록 구현하려하는데,
이 방식에 동의하는지 궁금합니다..!
