### PR TITLE
#268 [feat] SSO 관련 end point 수정 & 개발 환경 로깅 추가

### DIFF
--- a/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/auth/api/AuthApiController.java
@@ -47,7 +47,7 @@ public class AuthApiController implements AuthApi {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    @GetMapping("/api/v1/authorize")
+    @GetMapping("/api/v1/auth/authorize")
     public ResponseEntity<BaseResponse<?>> authorize(
             @RequestParam String type,
             @RequestParam String code,
@@ -68,7 +68,7 @@ public class AuthApiController implements AuthApi {
 
     @Override
     @PostMapping(
-            path = "/api/v1/token",
+            path = "/api/v1/auth/token",
             consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
     )
     public ResponseEntity<BaseResponse<?>> token(AccessTokenRequest accessTokenRequest) {

--- a/operation-auth/src/main/java/org/sopt/makers/operation/config/SecurityConfig.java
+++ b/operation-auth/src/main/java/org/sopt/makers/operation/config/SecurityConfig.java
@@ -60,8 +60,6 @@ public class SecurityConfig {
                         authorizeHttpRequests
                                 .requestMatchers(new AntPathRequestMatcher("/api/v1/auth/*")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/api/v1/test/**")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/api/v1/authorize")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/api/v1/token")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/error")).permitAll()
                                 .anyRequest().authenticated())
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/scripts/run_new_was.sh
+++ b/scripts/run_new_was.sh
@@ -28,7 +28,7 @@ fi
 
 if [ "$DEPLOYMENT_GROUP_NAME" == "dev" ]
 then
-   nohup java -jar -Dserver.port=${TARGET_PORT} -Dspring.profiles.active=dev /home/ubuntu/operation/operation-api/build/libs/operation-api-0.0.1-SNAPSHOT.jar > /dev/null 2> /dev/null < /dev/null &
+   nohup java -jar -Dserver.port=${TARGET_PORT} -Dspring.profiles.active=dev /home/ubuntu/operation/operation-api/build/libs/operation-api-0.0.1-SNAPSHOT.jar > nohup.out 2>&1 </dev/null &
    echo "> Now new WAS runs at ${TARGET_PORT}."
 fi
 sleep 10


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #268 

## Work Description ✏️

### SSO 관련 END POINT 앞에 auth 추가

![image](https://github.com/sopt-makers/sopt-operation-backend/assets/82709044/b008b9a6-2cca-4004-a9ec-38704633130b)
요청이 들어올 때 마다, JwtAuthenticactionFilter.java 파일 내부의 해당 메서드를 거쳐갑니다.
이 때 if 문 내부에 들어가게 되면 access token을 확인하는 로직이 실행됩니다.
하지만 **sso 관련 api는 아직 token이 없기 때문에 if 문을 거치면 안됩니다.**
따라서 **sso 관련 api의 end point 앞에 auth를 추가해서 if문을 거치지 않도록** 만들었습니다.

### dev 환경 로깅 추가

현재 dev 환경에는 로깅을 하지 않기 때문에 에러를 추적하기 매우 매우 힘들었습니다.
따라서 dev 환경에서는 nohup.out 파일에 console log를 저장하는 방향으로 수정했습니다.

`nohup.out 2>&1 </dev/null &`
표준 출력 & 에러 출력은 nohup.out 에다 하고, 표준 입력은 /dev/null 로 리다이렉션 시킵니다.

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
