### PR TITLE
[FEAT] GET  /internal/user/me API 구현

### DIFF
--- a/operation-api/src/main/java/org/sopt/makers/operation/common/handler/ErrorHandler.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/handler/ErrorHandler.java
@@ -3,6 +3,8 @@ package org.sopt.makers.operation.common.handler;
 import org.sopt.makers.operation.dto.BaseResponse;
 import org.sopt.makers.operation.exception.AuthException;
 import org.sopt.makers.operation.util.ApiResponseUtil;
+import org.sopt.makers.operation.exception.UserException;
+import org.sopt.makers.operation.exception.ParameterDecodeCustomException;
 import org.sopt.makers.operation.exception.AdminFailureException;
 import org.sopt.makers.operation.exception.AlarmException;
 import org.sopt.makers.operation.exception.AttendanceException;
@@ -12,6 +14,7 @@ import org.sopt.makers.operation.exception.MemberException;
 import org.sopt.makers.operation.exception.ScheduleException;
 import org.sopt.makers.operation.exception.SubLectureException;
 import org.sopt.makers.operation.exception.TokenException;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -46,6 +49,12 @@ public class ErrorHandler {
         return ApiResponseUtil.failure(ex.getFailureCode());
     }
 
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<BaseResponse<?>> userException(UserException ex) {
+        log.error(ex.getMessage());
+        return ApiResponseUtil.failure(ex.getFailureCode());
+    }
+
     @ExceptionHandler(LectureException.class)
     public ResponseEntity<BaseResponse<?>> lectureException(LectureException ex) {
         log.error(ex.getMessage());
@@ -60,6 +69,12 @@ public class ErrorHandler {
 
     @ExceptionHandler(DateTimeParseCustomException.class)
     public ResponseEntity<BaseResponse<?>> dateTimeParseException(DateTimeParseCustomException ex) {
+        return ApiResponseUtil.failure(ex.getFailureCode());
+    }
+
+    @ExceptionHandler(ParameterDecodeCustomException.class)
+    public ResponseEntity<BaseResponse<?>> ParameterDecodeException(ParameterDecodeCustomException ex) {
+        log.error(ex.getMessage());
         return ApiResponseUtil.failure(ex.getFailureCode());
     }
 

--- a/operation-api/src/main/java/org/sopt/makers/operation/common/util/CommonUtils.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/util/CommonUtils.java
@@ -1,14 +1,35 @@
 package org.sopt.makers.operation.common.util;
 
+import java.util.List;
+import java.util.Arrays;
+import java.net.URLEncoder;
 import java.security.Principal;
+import java.io.UnsupportedEncodingException;
 
+import org.sopt.makers.operation.code.failure.UserFailureCode;
+import org.sopt.makers.operation.exception.ParameterDecodeCustomException;
 import org.springframework.context.annotation.Configuration;
 
 import lombok.NonNull;
 
 @Configuration
 public class CommonUtils {
+
+	private static final String DECODING_CHARSET = "UTF-8";
+	private static final String DELIMITER_ID_PARAMETER = ",";
+
 	public long getMemberId(@NonNull Principal principal) {
 		return Long.parseLong(principal.getName());
+	}
+
+	public List<Long> getIdsFromParameter(@NonNull String parameter)  {
+		try {
+			String encodedParameter = URLEncoder.encode(parameter, DECODING_CHARSET);
+			return Arrays.stream(encodedParameter.split(DELIMITER_ID_PARAMETER))
+					.map(id -> Long.parseLong(id.trim()))
+					.toList();
+		} catch (UnsupportedEncodingException ex) {
+			throw new ParameterDecodeCustomException(UserFailureCode.INVALID_PARAMETER, parameter);
+		}
 	}
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/common/util/CommonUtils.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/util/CommonUtils.java
@@ -1,13 +1,7 @@
 package org.sopt.makers.operation.common.util;
 
-import java.util.List;
-import java.util.Arrays;
-import java.net.URLEncoder;
 import java.security.Principal;
-import java.io.UnsupportedEncodingException;
 
-import org.sopt.makers.operation.code.failure.UserFailureCode;
-import org.sopt.makers.operation.exception.ParameterDecodeCustomException;
 import org.springframework.context.annotation.Configuration;
 
 import lombok.NonNull;
@@ -15,21 +9,8 @@ import lombok.NonNull;
 @Configuration
 public class CommonUtils {
 
-	private static final String DECODING_CHARSET = "UTF-8";
-	private static final String DELIMITER_ID_PARAMETER = ",";
-
 	public long getMemberId(@NonNull Principal principal) {
 		return Long.parseLong(principal.getName());
 	}
 
-	public List<Long> getIdsFromParameter(@NonNull String parameter)  {
-		try {
-			String encodedParameter = URLEncoder.encode(parameter, DECODING_CHARSET);
-			return Arrays.stream(encodedParameter.split(DELIMITER_ID_PARAMETER))
-					.map(id -> Long.parseLong(id.trim()))
-					.toList();
-		} catch (UnsupportedEncodingException ex) {
-			throw new ParameterDecodeCustomException(UserFailureCode.INVALID_PARAMETER, parameter);
-		}
-	}
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApi.java
@@ -1,0 +1,65 @@
+package org.sopt.makers.operation.user.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.NonNull;
+import org.sopt.makers.operation.dto.BaseResponse;
+import org.springframework.http.ResponseEntity;
+
+import java.security.Principal;
+
+public interface UserApi {
+
+	@Operation(
+			security = @SecurityRequirement(name = "Authorization"),
+			summary = "본인 유저 정보 조회 API",
+			responses = {
+					@ApiResponse(
+							responseCode = "200",
+							description = "본인에 대한 유저 정보 조회가 성공한 경우"
+					),
+					@ApiResponse(
+							responseCode = "400",
+							description = "요청이 잘못된 경우"
+					),
+					@ApiResponse(
+							responseCode = "404",
+							description = "해당 토큰에 담긴 유저 정보에 해당하는 데이터가 존재하지 않은 경우"
+					),
+					@ApiResponse(
+							responseCode = "500",
+							description = "서버 내부 오류가 발생한 경우"
+					)
+			}
+	)
+	ResponseEntity<BaseResponse<?>> getUserInfoSelf(
+			@Parameter(hidden = true) @NonNull Principal principal);
+
+	@Operation(
+			security = @SecurityRequirement(name = "Authorization"),
+			summary = "복수 유저 정보 조회 API",
+			responses = {
+					@ApiResponse(
+							responseCode = "200",
+							description = "의도했던 유저 정보 조회가 성공한 경우"
+					),
+					@ApiResponse(
+							responseCode = "400",
+							description = "요청이 잘못된 경우"
+					),
+					@ApiResponse(
+							responseCode = "404",
+							description = "쿼리 파라미터에 담긴 유저 ID들 중 존재하지 않는 유저에 대한 ID가 존재하는 경우"
+					),
+					@ApiResponse(
+							responseCode = "500",
+							description = "서버 내부 오류가 발생한 경우"
+					)
+			}
+	)
+	ResponseEntity<BaseResponse<?>> getUserInfoOf(
+			@Parameter(hidden = true) @NonNull Principal principal,
+			@Parameter @NonNull String targetUserIds);
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApiController.java
@@ -4,8 +4,10 @@ import lombok.val;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import org.sopt.makers.operation.code.failure.UserFailureCode;
 import org.sopt.makers.operation.common.util.CommonUtils;
 import org.sopt.makers.operation.dto.BaseResponse;
+import org.sopt.makers.operation.exception.ParameterDecodeCustomException;
 import org.sopt.makers.operation.user.service.UserService;
 import org.sopt.makers.operation.util.ApiResponseUtil;
 
@@ -15,6 +17,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
+import java.util.Arrays;
+import java.util.List;
+import java.net.URLEncoder;
+import java.io.UnsupportedEncodingException;
 
 import static org.sopt.makers.operation.code.success.UserSuccessCode.SUCCESS_GET_USER;
 import static org.sopt.makers.operation.code.success.UserSuccessCode.SUCCESS_GET_USERS;
@@ -24,6 +30,9 @@ import static org.sopt.makers.operation.code.success.UserSuccessCode.SUCCESS_GET
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/internal/user")
 public class UserApiController implements UserApi {
+
+	private static final String DECODING_CHARSET = "UTF-8";
+	private static final String DELIMITER_ID_PARAMETER = ",";
 
 	private final UserService userService;
 	private final CommonUtils utils;
@@ -43,10 +52,20 @@ public class UserApiController implements UserApi {
 			@NonNull Principal principal,
 			@NonNull String targetUserIds
 	) {
-		val userIds = utils.getIdsFromParameter(targetUserIds);
+		val userIds = getIdsFromParameter(targetUserIds);
 		val response = userService.getUserInfos(userIds);
 		return ApiResponseUtil.success(SUCCESS_GET_USERS, response);
 	}
 
+	private List<Long> getIdsFromParameter(@NonNull String parameter)  {
+		try {
+			String encodedParameter = URLEncoder.encode(parameter, DECODING_CHARSET);
+			return Arrays.stream(encodedParameter.split(DELIMITER_ID_PARAMETER))
+					.map(id -> Long.parseLong(id.trim()))
+					.toList();
+		} catch (UnsupportedEncodingException ex) {
+			throw new ParameterDecodeCustomException(UserFailureCode.INVALID_PARAMETER, parameter);
+		}
+	}
 
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApiController.java
@@ -1,0 +1,52 @@
+package org.sopt.makers.operation.user.api;
+
+import lombok.val;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.sopt.makers.operation.common.util.CommonUtils;
+import org.sopt.makers.operation.dto.BaseResponse;
+import org.sopt.makers.operation.user.service.UserService;
+import org.sopt.makers.operation.util.ApiResponseUtil;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+import static org.sopt.makers.operation.code.success.UserSuccessCode.SUCCESS_GET_USER;
+import static org.sopt.makers.operation.code.success.UserSuccessCode.SUCCESS_GET_USERS;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/internal/user")
+public class UserApiController implements UserApi {
+
+	private final UserService userService;
+	private final CommonUtils utils;
+
+	@Override
+	@GetMapping("/me")
+	public ResponseEntity<BaseResponse<?>> getUserInfoSelf(
+			@NonNull Principal principal
+	) {
+		val userId = utils.getMemberId(principal);
+		val response = userService.getUserInfo(userId);
+		return ApiResponseUtil.success(SUCCESS_GET_USER, response);
+	}
+
+	@Override
+	public ResponseEntity<BaseResponse<?>> getUserInfoOf(
+			@NonNull Principal principal,
+			@NonNull String targetUserIds
+	) {
+		val userIds = utils.getIdsFromParameter(targetUserIds);
+		val response = userService.getUserInfos(userIds);
+		return ApiResponseUtil.success(SUCCESS_GET_USERS, response);
+	}
+
+
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/ActivityTotalVO.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/ActivityTotalVO.java
@@ -1,0 +1,33 @@
+package org.sopt.makers.operation.user.dto.response;
+
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import org.sopt.makers.operation.user.domain.Part;
+import org.sopt.makers.operation.user.domain.Team;
+import org.sopt.makers.operation.user.domain.Position;
+import org.sopt.makers.operation.user.domain.UserGenerationHistory;
+
+import static lombok.AccessLevel.*;
+
+@Builder(access = PRIVATE)
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+@RequiredArgsConstructor(access = PRIVATE)
+public record ActivityTotalVO(
+        int generation,
+        Part part,
+        Team team,
+        Position position
+) {
+    public static ActivityTotalVO from(UserGenerationHistory history) {
+        return ActivityTotalVO.builder()
+                .generation(history.getGeneration())
+                .part(history.getPart())
+                .team(history.getTeam())
+                .position(history.getPosition())
+                .build();
+    }
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/ActivityTotalVO.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/ActivityTotalVO.java
@@ -7,7 +7,7 @@ import org.sopt.makers.operation.user.domain.Team;
 import org.sopt.makers.operation.user.domain.Position;
 import org.sopt.makers.operation.user.domain.UserGenerationHistory;
 
-import static lombok.AccessLevel.*;
+import static lombok.AccessLevel.PRIVATE;
 
 @Builder(access = PRIVATE)
 public record ActivityTotalVO(

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/ActivityTotalVO.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/ActivityTotalVO.java
@@ -11,6 +11,7 @@ import static lombok.AccessLevel.*;
 
 @Builder(access = PRIVATE)
 public record ActivityTotalVO(
+        long id,
         int generation,
         Part part,
         Team team,
@@ -18,6 +19,7 @@ public record ActivityTotalVO(
 ) {
     public static ActivityTotalVO from(UserGenerationHistory history) {
         return ActivityTotalVO.builder()
+                .id(history.getId())
                 .generation(history.getGeneration())
                 .part(history.getPart())
                 .team(history.getTeam())

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/ActivityTotalVO.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/ActivityTotalVO.java
@@ -1,9 +1,6 @@
 package org.sopt.makers.operation.user.dto.response;
 
 import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import org.sopt.makers.operation.user.domain.Part;
 import org.sopt.makers.operation.user.domain.Team;
@@ -13,9 +10,6 @@ import org.sopt.makers.operation.user.domain.UserGenerationHistory;
 import static lombok.AccessLevel.*;
 
 @Builder(access = PRIVATE)
-@NoArgsConstructor(access = PRIVATE)
-@AllArgsConstructor(access = PRIVATE)
-@RequiredArgsConstructor(access = PRIVATE)
 public record ActivityTotalVO(
         int generation,
         Part part,

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserActivityInfoResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserActivityInfoResponse.java
@@ -10,15 +10,15 @@ import org.sopt.makers.operation.user.domain.UserGenerationHistory;
 import static lombok.AccessLevel.PRIVATE;
 
 @Builder(access = PRIVATE)
-public record ActivityTotalVO(
+public record UserActivityInfoResponse(
         long id,
         int generation,
         Part part,
         Team team,
         Position position
 ) {
-    public static ActivityTotalVO from(UserGenerationHistory history) {
-        return ActivityTotalVO.builder()
+    public static UserActivityInfoResponse from(UserGenerationHistory history) {
+        return UserActivityInfoResponse.builder()
                 .id(history.getId())
                 .generation(history.getGeneration())
                 .part(history.getPart())

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfoResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfoResponse.java
@@ -2,6 +2,7 @@ package org.sopt.makers.operation.user.dto.response;
 
 import java.util.List;
 
+import lombok.val;
 import lombok.Builder;
 
 import org.sopt.makers.operation.user.domain.User;
@@ -15,10 +16,10 @@ public record UserInfoResponse(
         String name,
         String phone,
         String profileImage,
-        List<ActivityTotalVO> activities
+        List<UserActivityInfoResponse> activities
 ) {
     public static UserInfoResponse of(User user, List<UserGenerationHistory> histories) {
-        List<ActivityTotalVO> activities = histories.stream().map(ActivityTotalVO::from).toList();
+        val activities = histories.stream().map(UserActivityInfoResponse::from).toList();
         return UserInfoResponse.builder()
                 .id(user.getId())
                 .name(user.getName())

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfoResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfoResponse.java
@@ -3,9 +3,6 @@ package org.sopt.makers.operation.user.dto.response;
 import java.util.List;
 
 import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import org.sopt.makers.operation.user.domain.User;
 import org.sopt.makers.operation.user.domain.UserGenerationHistory;
@@ -13,9 +10,6 @@ import org.sopt.makers.operation.user.domain.UserGenerationHistory;
 import static lombok.AccessLevel.*;
 
 @Builder(access = PRIVATE)
-@NoArgsConstructor(access = PRIVATE)
-@AllArgsConstructor(access = PRIVATE)
-@RequiredArgsConstructor(access = PRIVATE)
 public record UserInfoResponse(
         Long id,
         String name,

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfoResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,36 @@
+package org.sopt.makers.operation.user.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import org.sopt.makers.operation.user.domain.User;
+import org.sopt.makers.operation.user.domain.UserGenerationHistory;
+
+import static lombok.AccessLevel.*;
+
+@Builder(access = PRIVATE)
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+@RequiredArgsConstructor(access = PRIVATE)
+public record UserInfoResponse(
+        Long id,
+        String name,
+        String phone,
+        String profileImage,
+        List<ActivityTotalVO> activities
+) {
+    public static UserInfoResponse of(User user, List<UserGenerationHistory> histories) {
+        List<ActivityTotalVO> activities = histories.stream().map(ActivityTotalVO::from).toList();
+        return UserInfoResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .phone(user.getPhone())
+                .profileImage(user.getProfileImage())
+                .activities(activities)
+                .build();
+    }
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfoResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfoResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import org.sopt.makers.operation.user.domain.User;
 import org.sopt.makers.operation.user.domain.UserGenerationHistory;
 
-import static lombok.AccessLevel.*;
+import static lombok.AccessLevel.PRIVATE;
 
 @Builder(access = PRIVATE)
 public record UserInfoResponse(

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfosResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfosResponse.java
@@ -3,16 +3,10 @@ package org.sopt.makers.operation.user.dto.response;
 import java.util.List;
 
 import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import static lombok.AccessLevel.PRIVATE;
 
 @Builder(access = PRIVATE)
-@NoArgsConstructor(access = PRIVATE)
-@AllArgsConstructor(access = PRIVATE)
-@RequiredArgsConstructor(access = PRIVATE)
 public record UserInfosResponse(
         List<UserInfoResponse> users
 ) {

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfosResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/response/UserInfosResponse.java
@@ -1,0 +1,24 @@
+package org.sopt.makers.operation.user.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+@RequiredArgsConstructor(access = PRIVATE)
+public record UserInfosResponse(
+        List<UserInfoResponse> users
+) {
+    public static UserInfosResponse of(List<UserInfoResponse> userInfos) {
+        return UserInfosResponse.builder()
+                .users(userInfos)
+                .build();
+    }
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserService.java
@@ -1,0 +1,11 @@
+package org.sopt.makers.operation.user.service;
+
+import java.util.List;
+
+import org.sopt.makers.operation.user.dto.response.UserInfoResponse;
+import org.sopt.makers.operation.user.dto.response.UserInfosResponse;
+
+public interface UserService {
+    UserInfoResponse getUserInfo(Long userId);
+    UserInfosResponse getUserInfos(List<Long> userIds);
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserServiceImpl.java
@@ -1,0 +1,35 @@
+package org.sopt.makers.operation.user.service;
+
+import java.util.List;
+
+import lombok.val;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import org.sopt.makers.operation.user.repository.UserRepository;
+import org.sopt.makers.operation.user.repository.history.UserGenerationHistoryRepository;
+import org.sopt.makers.operation.user.dto.response.UserInfoResponse;
+import org.sopt.makers.operation.user.dto.response.UserInfosResponse;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final UserGenerationHistoryRepository generationHistoryRepository;
+
+    @Override
+    public UserInfoResponse getUserInfo(Long userId) {
+        val targetUser = userRepository.findUserById(userId);
+        val histories = generationHistoryRepository.findAllHistoryByUserId(userId);
+        return UserInfoResponse.of(targetUser, histories);
+    }
+
+    @Override
+    public UserInfosResponse getUserInfos(List<Long> userIds) {
+        return null;
+    }
+}

--- a/operation-api/src/test/java/org/sopt/makers/operation/user/api/UserApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/user/api/UserApiControllerTest.java
@@ -1,0 +1,110 @@
+package org.sopt.makers.operation.user.api;
+
+import java.security.Principal;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.sopt.makers.operation.user.domain.*;
+import org.sopt.makers.operation.user.dto.response.UserInfoResponse;
+import org.sopt.makers.operation.user.service.UserService;
+import org.sopt.makers.operation.jwt.JwtTokenProvider;
+import org.sopt.makers.operation.common.util.CommonUtils;
+import org.sopt.makers.operation.common.handler.ErrorHandler;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@Import({UserApiController.class, ErrorHandler.class})
+@ExtendWith(MockitoExtension.class)
+@ContextConfiguration(classes = {UserApiController.class})
+@WebMvcTest(
+        controllers = {UserApiController.class},
+        excludeAutoConfiguration =  {SecurityAutoConfiguration.class}
+)
+@DisplayName("[[ Unit Test ]] - User Controller ")
+class UserApiControllerTest {
+
+    final String userInfoSelfUri = "/api/v1/internal/user/me";
+
+    @MockBean
+    UserService userService;
+
+    @MockBean
+    JwtTokenProvider tokenProvider;
+    @MockBean
+    CommonUtils commonUtils;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Nested
+    @DisplayName("[TEST] 성공한 경우에 대한 테스트")
+    class SuccessTest {
+
+        @Test
+        @DisplayName("Case1. 요청자 자신에 대한 유저 정보 조회 성공 - /internal/user/me")
+        void successUserInfoSelf() throws Exception {
+            User mockedUser = mock(User.class);
+            UserGenerationHistory mockedHistory = mock(UserGenerationHistory.class);
+            given(mockedUser.getId()).willReturn(1L);
+            given(mockedUser.getName()).willReturn("TestUser");
+            given(mockedUser.getPhone()).willReturn("01012345678");
+            given(mockedUser.getProfileImage()).willReturn("TestImageUrl");
+
+            given(mockedHistory.getId()).willReturn(1L);
+            given(mockedHistory.getPart()).willReturn(Part.SERVER);
+            given(mockedHistory.getGeneration()).willReturn(32);
+            given(mockedHistory.getTeam()).willReturn(Team.OPERATION);
+            given(mockedHistory.getPosition()).willReturn(Position.MEMBER);
+
+            Principal mockPrincipal = mock(Principal.class);
+            given(mockPrincipal.getName()).willReturn("1");
+
+            UserInfoResponse expectServiceResult = UserInfoResponse.of(mockedUser, List.of(mockedHistory));
+            given(userService.getUserInfo(anyLong())).willReturn(expectServiceResult);
+
+            mockMvc.perform(
+                            get(userInfoSelfUri)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .principal(mockPrincipal))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value("true"))
+                    .andExpect(jsonPath("$.message").value("유저 정보 조회 성공"))
+
+                    .andExpect(jsonPath("$.data.id").value("1"))
+                    .andExpect(jsonPath("$.data.name").value("TestUser"))
+                    .andExpect(jsonPath("$.data.phone").value("01012345678"))
+                    .andExpect(jsonPath("$.data.profileImage").value("TestImageUrl"))
+
+                    .andExpect(jsonPath("$.data.activities[0].id").value("1"))
+                    .andExpect(jsonPath("$.data.activities[0].generation").value("32"))
+                    .andExpect(jsonPath("$.data.activities[0].part").value("SERVER"))
+                    .andExpect(jsonPath("$.data.activities[0].team").value("OPERATION"))
+                    .andExpect(jsonPath("$.data.activities[0].position").value("MEMBER"));
+
+        }
+
+    }
+
+
+}

--- a/operation-api/src/test/java/org/sopt/makers/operation/user/service/UserServiceTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/user/service/UserServiceTest.java
@@ -1,0 +1,77 @@
+package org.sopt.makers.operation.user.service;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.sopt.makers.operation.user.dto.response.UserInfoResponse;
+import org.sopt.makers.operation.user.domain.User;
+import org.sopt.makers.operation.user.domain.Team;
+import org.sopt.makers.operation.user.domain.Position;
+import org.sopt.makers.operation.user.domain.UserGenerationHistory;
+import org.sopt.makers.operation.user.repository.UserRepository;
+import org.sopt.makers.operation.user.repository.history.UserGenerationHistoryRepository;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[[ Unit Test ]] - UserService ")
+class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    UserGenerationHistoryRepository userGenerationHistoryRepository;
+    @InjectMocks
+    UserServiceImpl userService;
+
+    @Nested
+    @DisplayName("[TEST] 성공한 경우에 대한 테스트")
+    class SuccessTest {
+
+        @Test
+        @DisplayName("Case1. 의도했던 데이터로 구성된 Response 데이터가 반환된다.")
+        void expectResponseReturnSuccess() {
+            // given
+            User mockedUser = mock(User.class);
+            UserGenerationHistory mockedHistory = mock(UserGenerationHistory.class);
+            given(mockedUser.getId()).willReturn(1L);
+            given(mockedUser.getName()).willReturn("TestUser");
+            given(mockedUser.getPhone()).willReturn("01012345678");
+
+            given(mockedHistory.getId()).willReturn(1L);
+            given(mockedHistory.getGeneration()).willReturn(32);
+            given(mockedHistory.getTeam()).willReturn(Team.OPERATION);
+            given(mockedHistory.getPosition()).willReturn(Position.MEMBER);
+
+            given(userRepository.findUserById(1L)).willReturn(mockedUser);
+            given(userGenerationHistoryRepository.findAllHistoryByUserId(1L)).willReturn(List.of(mockedHistory));
+
+            Long targetUserId = 1L;
+
+            // when
+            UserInfoResponse userInfo = userService.getUserInfo(targetUserId);
+
+            // then
+            assertThat(userInfo).usingRecursiveComparison()
+                    .isEqualTo(UserInfoResponse.of(mockedUser, List.of(mockedHistory)));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("[TEST] 실패한 경우에 대한 테스트")
+    class FailureTest {
+
+    }
+
+}

--- a/operation-api/src/test/java/org/sopt/makers/operation/user/service/UserServiceTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/user/service/UserServiceTest.java
@@ -57,13 +57,13 @@ class UserServiceTest {
             given(userGenerationHistoryRepository.findAllHistoryByUserId(1L)).willReturn(List.of(mockedHistory));
 
             Long targetUserId = 1L;
+            UserInfoResponse expected = UserInfoResponse.of(mockedUser, List.of(mockedHistory));
 
             // when
-            UserInfoResponse userInfo = userService.getUserInfo(targetUserId);
+            UserInfoResponse response = userService.getUserInfo(targetUserId);
 
             // then
-            assertThat(userInfo).usingRecursiveComparison()
-                    .isEqualTo(UserInfoResponse.of(mockedUser, List.of(mockedHistory)));
+            assertThat(response).usingRecursiveComparison().isEqualTo(expected);
         }
 
     }

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/UserFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/UserFailureCode.java
@@ -1,0 +1,25 @@
+package org.sopt.makers.operation.code.failure;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserFailureCode implements FailureCode{
+
+    // 400
+    INVALID_PARAMETER(BAD_REQUEST, "잘못된 형식의 회원 정보 요청입니다."),
+
+    // 404
+    INVALID_USER(NOT_FOUND, "존재하지 않는 회원입니다."),
+    INVALID_HISTORY(NOT_FOUND, "해당 유저의 활동 이력을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/success/UserSuccessCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/success/UserSuccessCode.java
@@ -1,0 +1,19 @@
+package org.sopt.makers.operation.code.success;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserSuccessCode implements SuccessCode {
+    SUCCESS_GET_USER(OK, "유저 정보 조회 성공"),
+    SUCCESS_GET_USERS(OK, "전체 유저 정보 조회 성공"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/exception/ParameterDecodeCustomException.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/exception/ParameterDecodeCustomException.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.operation.exception;
+
+import lombok.Getter;
+import org.sopt.makers.operation.code.failure.FailureCode;
+
+
+@Getter
+public class ParameterDecodeCustomException extends RuntimeException {
+
+    private final FailureCode failureCode;
+
+    public ParameterDecodeCustomException(FailureCode failureCode, String parameter) {
+        super(String.format("[ParameterDecodeCustomException] : %s (parameter = %s)", failureCode.getMessage(), parameter));
+        this.failureCode = failureCode;
+    }
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/exception/UserException.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/exception/UserException.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.operation.exception;
+
+import lombok.Getter;
+import org.sopt.makers.operation.code.failure.FailureCode;
+
+@Getter
+public class UserException extends RuntimeException{
+
+    private final FailureCode failureCode;
+
+    public UserException(FailureCode failureCode) {
+        super("[UserException] : " + failureCode.getMessage());
+        this.failureCode = failureCode;
+    }
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/UserRepository.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.operation.user.repository;
+
+import org.sopt.makers.operation.code.failure.UserFailureCode;
+import org.sopt.makers.operation.exception.UserException;
+import org.sopt.makers.operation.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long>  {
+    default User findUserById(Long userId) {
+        return findById(userId).orElseThrow(() -> new UserException(UserFailureCode.INVALID_USER));
+    }
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/UserRepository.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/UserRepository.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>  {
+
     default User findUserById(Long userId) {
         return findById(userId).orElseThrow(() -> new UserException(UserFailureCode.INVALID_USER));
     }
+
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/history/UserGenerationHistoryRepository.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/history/UserGenerationHistoryRepository.java
@@ -11,7 +11,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 @Repository
 public interface UserGenerationHistoryRepository extends JpaRepository<UserGenerationHistory, Long> {
+
     List<UserGenerationHistory> findAllByUserId(Long userId);
+
     default List<UserGenerationHistory> findAllHistoryByUserId(Long userId) {
         List<UserGenerationHistory> histories = findAllByUserId(userId);
         if (histories.isEmpty()) {
@@ -19,4 +21,5 @@ public interface UserGenerationHistoryRepository extends JpaRepository<UserGener
         }
         return histories;
     }
+
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/history/UserGenerationHistoryRepository.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/history/UserGenerationHistoryRepository.java
@@ -2,6 +2,7 @@ package org.sopt.makers.operation.user.repository.history;
 
 import java.util.List;
 
+import lombok.val;
 import org.sopt.makers.operation.exception.UserException;
 import org.sopt.makers.operation.code.failure.UserFailureCode;
 import org.sopt.makers.operation.user.domain.UserGenerationHistory;
@@ -15,7 +16,7 @@ public interface UserGenerationHistoryRepository extends JpaRepository<UserGener
     List<UserGenerationHistory> findAllByUserId(Long userId);
 
     default List<UserGenerationHistory> findAllHistoryByUserId(Long userId) {
-        List<UserGenerationHistory> histories = findAllByUserId(userId);
+        val histories = findAllByUserId(userId);
         if (histories.isEmpty()) {
             throw new UserException(UserFailureCode.INVALID_HISTORY);
         }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/history/UserGenerationHistoryRepository.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/history/UserGenerationHistoryRepository.java
@@ -1,0 +1,22 @@
+package org.sopt.makers.operation.user.repository.history;
+
+import java.util.List;
+
+import org.sopt.makers.operation.exception.UserException;
+import org.sopt.makers.operation.code.failure.UserFailureCode;
+import org.sopt.makers.operation.user.domain.UserGenerationHistory;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@Repository
+public interface UserGenerationHistoryRepository extends JpaRepository<UserGenerationHistory, Long> {
+    List<UserGenerationHistory> findAllByUserId(Long userId);
+    default List<UserGenerationHistory> findAllHistoryByUserId(Long userId) {
+        List<UserGenerationHistory> histories = findAllByUserId(userId);
+        if (histories.isEmpty()) {
+            throw new UserException(UserFailureCode.INVALID_HISTORY);
+        }
+        return histories;
+    }
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/identityinfo/UserIdentityInfoRepository.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/identityinfo/UserIdentityInfoRepository.java
@@ -7,5 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserIdentityInfoRepository extends JpaRepository<UserIdentityInfo, Long> {
+
     Optional<UserIdentityInfo> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
 }

--- a/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.TestInstance.*;
 
 @DataJpaTest
-@DisplayName("[[ Unit Test ]] - UserRepository >")
+@DisplayName("[[ Unit Test ]] - UserRepository")
 @EntityScan(basePackages = "org.sopt.makers.operation.user")
 @ContextConfiguration(classes = {
         UserRepository.class, UserGenerationHistoryRepository.class

--- a/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
@@ -1,0 +1,180 @@
+package org.sopt.makers.operation.user.repository;
+
+import lombok.val;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.ArrayList;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.sopt.makers.operation.user.domain.User;
+import org.sopt.makers.operation.user.domain.Gender;
+import org.sopt.makers.operation.user.repository.history.UserGenerationHistoryRepository;
+import org.sopt.makers.operation.exception.UserException;
+import org.sopt.makers.operation.code.failure.UserFailureCode;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.TestInstance.*;
+
+@DataJpaTest
+@DisplayName("[[ Unit Test ]] - UserRepository >")
+@EntityScan(basePackages = "org.sopt.makers.operation.user")
+@ContextConfiguration(classes = {
+        UserRepository.class, UserGenerationHistoryRepository.class
+})
+@EnableAutoConfiguration
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Nested
+    @Order(1)
+    @DisplayName("[TEST] 단일 유저 대상 단일 ID로 조회하는 시나리오")
+    @TestInstance(Lifecycle.PER_CLASS)
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class SingleUserTest {
+
+        private User user;
+        @BeforeEach
+        void setUpSingleUser() {
+            User userEntity = User.builder()
+                    .email("test@test.com")
+                    .phone("010-0000-0000")
+                    .gender(Gender.MALE)
+                    .name("TestUser")
+                    .profileImage("DummyImageUrl")
+                    .birthday(LocalDate.of(1999, 12,4))
+                    .build();
+            user = userRepository.save(userEntity);
+        }
+
+        @Test
+        @Order(1)
+        @DisplayName("Case1. 단일 유저에 대한 저장 및 조회 성공")
+        void getSuccessTest() {
+            // given
+            val userId = user.getId();
+
+            // when
+            val result = userRepository.findUserById(userId);
+
+            // then
+            assertThat(result.getId()).isEqualTo(userId);
+            assertThat(result.getName()).isEqualTo("TestUser");
+            assertThat(result.getPhone()).isEqualTo("010-0000-0000");
+            assertThat(result.getEmail()).isEqualTo("test@test.com");
+            assertThat(result.getBirthday()).isEqualTo(LocalDate.of(1999, 12, 4));
+            assertThat(result.getGender()).isEqualTo(Gender.MALE);
+            assertThat(result.getProfileImage()).isEqualTo("DummyImageUrl");
+        }
+
+        @Test
+        @Order(2)
+        @DisplayName("Case2. 존재하지 않은 userId일 경우, 예외 반환")
+        void getFailTest() {
+            // given
+            val invalidUserId = 0L;
+
+            // when & then
+            val userException = assertThrows(UserException.class, () -> userRepository.findUserById(invalidUserId));
+            assertThat(userException.getFailureCode()).isEqualTo(UserFailureCode.INVALID_USER);
+        }
+
+    }
+
+    @Nested
+    @Order(2)
+    @TestInstance(Lifecycle.PER_CLASS)
+    @DisplayName("[TEST] 여러 유저가 저장된 상태에서 단일 ID로 조회하는 시나리오")
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class MultiUserTest {
+
+        private Map<Long, User> cachedUsers;
+
+        @BeforeAll
+        void setUpMultiUser() {
+            cachedUsers = new HashMap<>();
+            List<User> users = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                val dummyUser = User.builder()
+                        .email(String.format("test%d@test.com", i))
+                        .phone(String.format("010-000%d-000%d", i, i))
+                        .gender(i % 2 == 0 ? Gender.MALE : Gender.FEMALE)
+                        .name(String.format("TestUser%d", i))
+                        .profileImage(String.format("DummyImageUrl%d", i))
+                        .birthday(LocalDate.of(1999, 12, i + 1))
+                        .build();
+                users.add(dummyUser);
+            }
+            List<User> savedUsers = userRepository.saveAll(users);
+            savedUsers.forEach(user -> cachedUsers.put(user.getId(), user));
+        }
+
+        @Test
+        @Order(1)
+        @DisplayName("Case1. 여러 유저에 대한 저장 및 각 유저에 대한 조회 성공")
+        void getSuccessTest() {
+            for (Long userId : cachedUsers.keySet()) {
+                // given
+                val user = cachedUsers.get(userId);
+
+                // when
+                val result = userRepository.findUserById(userId);
+
+                // then
+                assertThat(result.getId()).isEqualTo(user.getId());
+                assertThat(result.getName()).isEqualTo(user.getName());
+                assertThat(result.getPhone()).isEqualTo(user.getPhone());
+                assertThat(result.getEmail()).isEqualTo(user.getEmail());
+                assertThat(result.getBirthday()).isEqualTo(user.getBirthday());
+                assertThat(result.getGender()).isEqualTo(user.getGender());
+                assertThat(result.getProfileImage()).isEqualTo(user.getProfileImage());
+            }
+
+        }
+
+        @Test
+        @DisplayName("Case2. 여러 유저 중 존재하지 않은 userId로 조회할 경우, 예외 반환")
+        void getFailTest() {
+            // given
+            Long invalidId = 0L;
+            Set<Long> ids = new HashSet<>();
+            ids.add(invalidId);
+            ids.addAll(cachedUsers.keySet());
+
+            for (Long userId : ids) {
+                if (userId.equals(invalidId)) {
+                    // when & then
+                    val userException = assertThrows(UserException.class, () -> userRepository.findUserById(invalidId));
+                    assertThat(userException.getFailureCode()).isEqualTo(UserFailureCode.INVALID_USER);
+                    return;
+                }
+            }
+        }
+    }
+
+
+}

--- a/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
@@ -66,7 +66,7 @@ class UserRepositoryTest {
 
         @Test
         @Order(1)
-        @DisplayName("Case1. 단일 유저에 대한 저장 및 조회 성공")
+        @DisplayName("Case1. 단일 유저에 대한 조회 성공")
         void getSuccessTest() {
             // given
             val userId = user.getId();

--- a/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
@@ -2,12 +2,6 @@ package org.sopt.makers.operation.user.repository;
 
 import lombok.val;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.List;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.ArrayList;
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
@@ -20,7 +14,6 @@ import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.BeforeAll;
 
 import org.sopt.makers.operation.user.domain.User;
 import org.sopt.makers.operation.user.domain.Gender;
@@ -33,9 +26,9 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.TestInstance.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.TestInstance.Lifecycle;
 
 @DataJpaTest
 @DisplayName("[[ Unit Test ]] - UserRepository")
@@ -112,68 +105,6 @@ class UserRepositoryTest {
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     class MultiUserTest {
 
-        private Map<Long, User> cachedUsers;
-
-        @BeforeAll
-        void setUpMultiUser() {
-            cachedUsers = new HashMap<>();
-            List<User> users = new ArrayList<>();
-            for (int i = 0; i < 10; i++) {
-                val dummyUser = User.builder()
-                        .email(String.format("test%d@test.com", i))
-                        .phone(String.format("010-000%d-000%d", i, i))
-                        .gender(i % 2 == 0 ? Gender.MALE : Gender.FEMALE)
-                        .name(String.format("TestUser%d", i))
-                        .profileImage(String.format("DummyImageUrl%d", i))
-                        .birthday(LocalDate.of(1999, 12, i + 1))
-                        .build();
-                users.add(dummyUser);
-            }
-            List<User> savedUsers = userRepository.saveAll(users);
-            savedUsers.forEach(user -> cachedUsers.put(user.getId(), user));
-        }
-
-        @Test
-        @Order(1)
-        @DisplayName("Case1. 여러 유저에 대한 저장 및 각 유저에 대한 조회 성공")
-        void getSuccessTest() {
-            for (Long userId : cachedUsers.keySet()) {
-                // given
-                val user = cachedUsers.get(userId);
-
-                // when
-                val result = userRepository.findUserById(userId);
-
-                // then
-                assertThat(result.getId()).isEqualTo(user.getId());
-                assertThat(result.getName()).isEqualTo(user.getName());
-                assertThat(result.getPhone()).isEqualTo(user.getPhone());
-                assertThat(result.getEmail()).isEqualTo(user.getEmail());
-                assertThat(result.getBirthday()).isEqualTo(user.getBirthday());
-                assertThat(result.getGender()).isEqualTo(user.getGender());
-                assertThat(result.getProfileImage()).isEqualTo(user.getProfileImage());
-            }
-
-        }
-
-        @Test
-        @DisplayName("Case2. 여러 유저 중 존재하지 않은 userId로 조회할 경우, 예외 반환")
-        void getFailTest() {
-            // given
-            Long invalidId = 0L;
-            Set<Long> ids = new HashSet<>();
-            ids.add(invalidId);
-            ids.addAll(cachedUsers.keySet());
-
-            for (Long userId : ids) {
-                if (userId.equals(invalidId)) {
-                    // when & then
-                    val userException = assertThrows(UserException.class, () -> userRepository.findUserById(invalidId));
-                    assertThat(userException.getFailureCode()).isEqualTo(UserFailureCode.INVALID_USER);
-                    return;
-                }
-            }
-        }
     }
 
 


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #259 
- closes T-10858

<br/>

## Work Description ✏️
- Request Header에 있는 Platform Token 토큰 기반 Principal 값으로 **본인(단일 유저)에 대한 유저 정보**를 조회하는 API입니다.
- 각 SOPT makers 프로덕트 서버들이 클라이언트(요청자) 자신의 정보가 필요할 때 호출하여 사용합니다.
- Repository 레이어 & Service 레이어에 대한 Unit Test 또한 수행했습니다.

<br/>
<br/>

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
> 양이 조금 많은 점 양해부탁드립니다..호호

## 🤔 고민한 점 & 알게된 점 & 궁금한 점
### 1️⃣ Response DTO Record 구현시 Builder를 추가적으로 사용해야 할지
이전 기수부터 이어져온 DTO 생성자 전략이 Builder 를 적용하여 **static 생성 메서드**를 사용하는 구조입니다.(`@Builder(access=private)` & `public static {DTO Class} of(...)`) 

`@Builder(access=private)`을 통해
만약 외부에서 해당 객체를 생성할 수 있는 방법을 단 한가지로 제어하기 위함이라면
Builder를 사용하지 않고 `@...ArgsConstructor(access = AccessLevel.PRIVATE)`을 활용해  public static 생성자 메서드만 선언하는 것도 무관할 것이라고 생각했습니다.
```java
@NoArgsConstructor(access = AccessLevel.PRIVATE)
@AllArgsConstructor(access = AccessLevel.PRIVATE)
@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
public record FooDto(
    int fooIntValue,
    long fooLongValue,
    String fooStringValue
){
    public static FooDto of(int intValue, long longValue, String stringValue) {
        return new FooDto(intValue, longValue, stringValue);
    }
}
```

하지만 `error: ...ArgsConstructor is only supported on a class or an enum.` 가 발생하며
Record 타입이기 때문에 기본적으로 AccessLevel이 PRIVATE인 `@NoArgsConstructor` & `@AllArgsConstructor` & `@RequiredArgsConstructor` 모두 사용할 수 없다는 문제가 확인했습니다.

- 생성에 필요한 Field 갯수가 너무 많을 경우, 가독성 저하
  - 자칫 new 생성자로 모든 필드를 일일이 주입받게 되면 코드 가독성과 사용 용이성이 떨어질 것으로 예상됩니다.
- 생성 방법을 단 하나의 `static` 메서드로 제어 가능

#### ※ 위 이유들을 근거로 지속적으로 `@Builder` + `public static 생성 메서드` 혼용을 채택하여 구현했습니다.

<br/>

### 2️⃣ DTO 객체 생성 시, Parameter로 도메인 객체를 직접 주입하는 것이 바람직한가
`Repository` 👉 `Service` 👉 `Controller`(3-Layer) 구조 중 Service에서 Controller로 전달하기 위해 DTO를 생성할 때, 
DTO 생성자 Parameter로 Domain Entity가 직접 주입되는 방식이 바람직한가에 대해 고민하였습니다.



> ❓ **궁금한 점**

Domain Entity 가 직접적으로 전달되는 것이 과연 안전한 것인가에서 시작되었는데요!
이에 3가지 방식을 고려하게 되었습니다.

🙏 여러분들의 의견이 궁금해요!!

1. `Repository` 👉 `Service` 간 협업과정에서 메시지 역할을 수행하는 **VO 객체** 를 구현하여 이를 DTO 생성시에 사용하는 방식
  - 자원 관리 비용 증가 위험이 있습니다.
  - 구조가 복잡해질 위험이 있습니다.
2. 무조건 DTO 생성 Parameter로 기본형 타입 값을 주입하는 방식
  -  생성 Parameter가 너무 많아질 수 있는 위험이 있습니다.
3. Domain Entity & VO & 기본 타입 값 혼용

#### ※ 우선 DTO의 구성 Field가 많으며 2번 방식을 배제하였고 1번의 경우, 팀원분들과의 논의가 필요하여 우선 Parameter로 Domain Entity를 주입하는 방식을 채택했습니다.

<br/>

### 3️⃣ Repository Test 수행 시, `@Transactional` 활용 & Roll-Back 등에 대한 처리까지 모두 고려해서 진행해야 하는가 (어차피 @DataJpaTest 내부적으로 부착되어 있긴하다) 

이번에 Domain Repository에 대해 `@DataJpaTest` 를 활용하는 과정에서 흥미로운 주제를 찾게되어 가져오게 되었습니다!

**전파레벨**까지 포함하여 여러가지 고려사항이 있는 요소인듯 하고
현업자분들 사이에서도 열렬한 논의가 진행되는 건인 것 같아요!!

여러분들과 얘기 나눠보고 싶어 이슈레이징 해봅니다!!

- 참고 블로그 
  - [https://jojoldu.tistory.com/761](https://jojoldu.tistory.com/761)
- 참고 유튜브 링크
  - [https://www.youtube.com/watch?v=PDhN6aiF7QQ](https://www.youtube.com/watch?v=PDhN6aiF7QQ)

<br/>

### 4️⃣ Mock 객체를 생성할 때, " ***Mock 테스트 과정에서 사용하지 않는 Field에 대해 Stubbing을 시도할 경우*** "에 `UnnecessaryStubbingException` 발생

- 참고 블로그 
  - [https://jhkimmm.tistory.com/28](https://jhkimmm.tistory.com/28)


<br/>
<br/>

## 🗑️ 기타
---
**JUnit 직접 구현하기** 관련 내용인데...ㅋㅋ 재밌겠당
  - [https://jojoldu.tistory.com/231](https://jojoldu.tistory.com/231)