### PR TITLE
[FEAT] PUT /internal/user API 구현

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -31,6 +31,14 @@ jobs:
           echo "${{ secrets.APPLICATION_DEV }}" >> ./application-dev.yml
           cat ./application-dev.yml
 
+      - name: Create application-test.yml
+        run: |
+          cd ./operation-domain/src/test
+          mkdir -p resources
+          touch ./resources/application-test.yml
+          echo "${{ secrets.APPLICATION_DOMAIN_TEST }}" >> ./application-test.yml
+          cat ./application-test.yml
+
       - name: 'Get key from Github Secrets'
         run: |
           pwd

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -31,6 +31,14 @@ jobs:
           echo "${{ secrets.APPLICATION_PROD }}" >> ./application-prod.yml
           cat ./application-prod.yml
 
+      - name: Create application-test.yml
+        run: |
+          cd ./operation-domain/src/test
+          mkdir -p resources
+          touch ./resources/application-test.yml
+          echo "${{ secrets.APPLICATION_DOMAIN_TEST }}" >> ./application-test.yml
+          cat ./application-test.yml
+
       - name: Build with Gradle
         run: ./gradlew build
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
           echo "${{ secrets.APPLICATION_DEV }}" >> ./application-dev.yml
           cat ./application-dev.yml
 
+      - name: Create application-test.yml
+        run: |
+          cd ./operation-domain/src/test
+          mkdir -p resources
+          touch ./resources/application-test.yml
+          echo "${{ secrets.APPLICATION_DOMAIN_TEST }}" >> ./application-test.yml
+          cat ./application-test.yml
+
       - name: 'Get key from Github Secrets'
         run: |
           pwd

--- a/operation-api/src/main/java/org/sopt/makers/operation/common/handler/ErrorHandler.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/handler/ErrorHandler.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.sopt.makers.operation.dto.BaseResponse;
+import org.sopt.makers.operation.exception.*;
 import org.sopt.makers.operation.util.ApiResponseUtil;
 
 import org.springframework.http.ResponseEntity;
@@ -12,19 +13,6 @@ import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
-
-import org.sopt.makers.operation.exception.AuthException;
-import org.sopt.makers.operation.exception.UserException;
-import org.sopt.makers.operation.exception.ParameterDecodeCustomException;
-import org.sopt.makers.operation.exception.AdminFailureException;
-import org.sopt.makers.operation.exception.AlarmException;
-import org.sopt.makers.operation.exception.AttendanceException;
-import org.sopt.makers.operation.exception.DateTimeParseCustomException;
-import org.sopt.makers.operation.exception.LectureException;
-import org.sopt.makers.operation.exception.MemberException;
-import org.sopt.makers.operation.exception.ScheduleException;
-import org.sopt.makers.operation.exception.SubLectureException;
-import org.sopt.makers.operation.exception.TokenException;
 
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -100,6 +88,12 @@ public class ErrorHandler {
 
     @ExceptionHandler(AuthException.class)
     public ResponseEntity<BaseResponse<?>> authException(AuthException ex) {
+        log.error(ex.getMessage());
+        return ApiResponseUtil.failure(ex.getFailureCode());
+    }
+
+    @ExceptionHandler(PermissionException.class)
+    public ResponseEntity<BaseResponse<?>> permissionException(PermissionException ex) {
         log.error(ex.getMessage());
         return ApiResponseUtil.failure(ex.getFailureCode());
     }

--- a/operation-api/src/main/java/org/sopt/makers/operation/common/util/PermissionValidator.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/util/PermissionValidator.java
@@ -1,0 +1,49 @@
+package org.sopt.makers.operation.common.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import org.sopt.makers.operation.code.failure.PermissionFailureCode;
+import org.sopt.makers.operation.code.failure.UserFailureCode;
+import org.sopt.makers.operation.config.ValueConfig;
+import org.sopt.makers.operation.exception.PermissionException;
+import org.sopt.makers.operation.exception.UserException;
+import org.sopt.makers.operation.user.domain.Position;
+import org.sopt.makers.operation.user.repository.history.UserGenerationHistoryRepository;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.Transactional;
+
+@Configuration
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PermissionValidator {
+
+    private final ValueConfig valueConfig;
+    private final UserGenerationHistoryRepository generationHistoryRepository;
+
+    public void validateIsSelf(long requestUserId, long targetUserId) {
+        if (!checkIsSelf(requestUserId, targetUserId)) {
+            throw new PermissionException(PermissionFailureCode.NO_PERMISSION_ONLY_SELF);
+        }
+    }
+
+    public void validateIsSelfOrExecutive(long requestUserId, long targetUserId) {
+        if (!checkIsSelf(requestUserId, targetUserId) || !checkIsExecutive(requestUserId)) {
+            throw new PermissionException(PermissionFailureCode.NO_PERMISSION_ONLY_SELF_INCLUDE_EXECUTIVE);
+        }
+    }
+
+    private boolean checkIsSelf(long requesterId, long targetId) {
+        return requesterId == targetId;
+    }
+
+    private boolean checkIsExecutive(long requesterId) {
+        val requesterCurrentHistory = generationHistoryRepository.findAllByUserId(requesterId).stream()
+                .filter(history -> history.getGeneration() == valueConfig.getGENERATION())
+                .findFirst()
+                .orElseThrow(() -> new UserException(UserFailureCode.NOT_FOUND_HISTORY));
+        return !Position.MEMBER.equals(requesterCurrentHistory.getPosition());
+    }
+
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/common/util/PermissionValidator.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/util/PermissionValidator.java
@@ -8,7 +8,6 @@ import org.sopt.makers.operation.code.failure.UserFailureCode;
 import org.sopt.makers.operation.config.ValueConfig;
 import org.sopt.makers.operation.exception.PermissionException;
 import org.sopt.makers.operation.exception.UserException;
-import org.sopt.makers.operation.user.domain.Position;
 import org.sopt.makers.operation.user.repository.history.UserGenerationHistoryRepository;
 
 import org.springframework.context.annotation.Configuration;
@@ -43,7 +42,7 @@ public class PermissionValidator {
                 .filter(history -> history.getGeneration() == valueConfig.getGENERATION())
                 .findFirst()
                 .orElseThrow(() -> new UserException(UserFailureCode.NOT_FOUND_HISTORY));
-        return !Position.MEMBER.equals(requesterCurrentHistory.getPosition());
+        return requesterCurrentHistory.isExecutive();
     }
 
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApi.java
@@ -9,6 +9,7 @@ import lombok.NonNull;
 import org.sopt.makers.operation.dto.BaseResponse;
 import org.sopt.makers.operation.user.dto.request.UserModifyRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.security.Principal;
 
@@ -92,5 +93,6 @@ public interface UserApi {
 			}
 	)
 	ResponseEntity<BaseResponse<?>> modifyUserInfoOf(
+			@PathVariable long userId,
 			@RequestBody UserModifyRequest userModifyRequest);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApi.java
@@ -2,10 +2,12 @@ package org.sopt.makers.operation.user.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.NonNull;
 import org.sopt.makers.operation.dto.BaseResponse;
+import org.sopt.makers.operation.user.dto.request.UserModifyRequest;
 import org.springframework.http.ResponseEntity;
 
 import java.security.Principal;
@@ -62,4 +64,33 @@ public interface UserApi {
 	ResponseEntity<BaseResponse<?>> getUserInfoOf(
 			@Parameter(hidden = true) @NonNull Principal principal,
 			@Parameter String targetUserIds);
+
+	@Operation(
+			security = @SecurityRequirement(name = "Authorization"),
+			summary = "유저 정보 수정 API",
+			responses = {
+					@ApiResponse(
+							responseCode = "204",
+							description = "유저 정보 수정 성공한 경우"
+					),
+					@ApiResponse(
+							responseCode = "400",
+							description = """
+									요청이 잘못된 경우<br/>
+									1. Request DTO 내 Validation에 실패한 경우(NotNull/NotEmpty)
+									2. 임원진(Position != MEMBER)이 Team 변경을 요청한 경우
+									"""
+					),
+					@ApiResponse(
+							responseCode = "404",
+							description = "해당 토큰에 담긴 유저 정보에 해당하는 데이터가 존재하지 않은 경우"
+					),
+					@ApiResponse(
+							responseCode = "500",
+							description = "서버 내부 오류가 발생한 경우"
+					)
+			}
+	)
+	ResponseEntity<BaseResponse<?>> modifyUserInfoOf(
+			@RequestBody UserModifyRequest userModifyRequest);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApi.java
@@ -93,6 +93,7 @@ public interface UserApi {
 			}
 	)
 	ResponseEntity<BaseResponse<?>> modifyUserInfoOf(
+			@Parameter(hidden = true) @NonNull Principal principal,
 			@PathVariable long userId,
 			@RequestBody UserModifyRequest userModifyRequest);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/api/UserApiController.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.operation.user.api;
 
+import jakarta.validation.Valid;
 import lombok.val;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -9,11 +10,13 @@ import org.sopt.makers.operation.common.util.CommonUtils;
 import org.sopt.makers.operation.dto.BaseResponse;
 import org.sopt.makers.operation.exception.ParameterDecodeCustomException;
 import org.sopt.makers.operation.exception.UserException;
+import org.sopt.makers.operation.user.dto.request.UserModifyRequest;
 import org.sopt.makers.operation.user.service.UserService;
 import org.sopt.makers.operation.util.ApiResponseUtil;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,7 +30,7 @@ import java.util.Objects;
 
 import static org.sopt.makers.operation.code.success.UserSuccessCode.SUCCESS_GET_USER;
 import static org.sopt.makers.operation.code.success.UserSuccessCode.SUCCESS_GET_USERS;
-
+import static org.sopt.makers.operation.code.success.UserSuccessCode.SUCCESS_PUT_USER;
 
 @RestController
 @RequiredArgsConstructor
@@ -60,6 +63,16 @@ public class UserApiController implements UserApi {
 		val userIds = getIdsFromParameter(targetUserIds);
 		val response = userService.getUserInfos(userIds);
 		return ApiResponseUtil.success(SUCCESS_GET_USERS, response);
+	}
+
+	@Override
+	@PutMapping
+	public ResponseEntity<BaseResponse<?>> modifyUserInfoOf(
+			@Valid UserModifyRequest userModifyRequest
+	) {
+		userService.modifyUserPersonalInfo(userModifyRequest);
+		userService.modifyUserActivityInfos(userModifyRequest.userActivities());
+		return ApiResponseUtil.success(SUCCESS_PUT_USER);
 	}
 
 	private List<Long> getIdsFromParameter(String parameter)  {

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/request/UserActivityModifyRequest.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/request/UserActivityModifyRequest.java
@@ -14,6 +14,7 @@ public record UserActivityModifyRequest(
         @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
         Part part,
         Team team,
+        @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
         Position position
 ) {
     private static final String ERROR_MESSAGE_FOR_NOT_NULL = "는 필수 값입니다.";

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/request/UserActivityModifyRequest.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/request/UserActivityModifyRequest.java
@@ -1,0 +1,20 @@
+package org.sopt.makers.operation.user.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.sopt.makers.operation.user.domain.Team;
+import org.sopt.makers.operation.user.domain.Part;
+import org.sopt.makers.operation.user.domain.Position;
+
+public record UserActivityModifyRequest(
+
+        @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
+        long activityId,
+        @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
+        int generation,
+        @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
+        Part part,
+        Team team,
+        Position position
+) {
+    private static final String ERROR_MESSAGE_FOR_NOT_NULL = "는 필수 값입니다.";
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/request/UserModifyRequest.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/request/UserModifyRequest.java
@@ -8,9 +8,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record UserModifyRequest(
-        @JsonProperty("id")
-        @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
-        long userId, // 추후 Admin에서 임원진이 회원 정보를 수정할 수 있도록 하기 위해
         @JsonProperty("name")
         @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
         String userName,

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/dto/request/UserModifyRequest.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/dto/request/UserModifyRequest.java
@@ -1,0 +1,29 @@
+package org.sopt.makers.operation.user.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record UserModifyRequest(
+        @JsonProperty("id")
+        @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
+        long userId, // 추후 Admin에서 임원진이 회원 정보를 수정할 수 있도록 하기 위해
+        @JsonProperty("name")
+        @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
+        String userName,
+        @JsonProperty("phone")
+        @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
+        String userPhone,
+        @JsonProperty("profileImage")
+        @NotNull(message = ERROR_MESSAGE_FOR_NOT_NULL)
+        String userProfileImage,
+        @JsonProperty("activities")
+        @NotEmpty(message = ERROR_MESSAGE_FOR_NOT_EMPTY)
+        List<UserActivityModifyRequest> userActivities
+) {
+        private static final String ERROR_MESSAGE_FOR_NOT_NULL = "는 필수 값입니다.";
+        private static final String ERROR_MESSAGE_FOR_NOT_EMPTY = "는 한 개 이상이어야 합니다.";
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserService.java
@@ -2,10 +2,15 @@ package org.sopt.makers.operation.user.service;
 
 import java.util.List;
 
+import org.sopt.makers.operation.user.dto.request.UserActivityModifyRequest;
+import org.sopt.makers.operation.user.dto.request.UserModifyRequest;
 import org.sopt.makers.operation.user.dto.response.UserInfoResponse;
 import org.sopt.makers.operation.user.dto.response.UserInfosResponse;
 
 public interface UserService {
     UserInfoResponse getUserInfo(Long userId);
     UserInfosResponse getUserInfos(List<Long> userIds);
+
+    void modifyUserPersonalInfo(UserModifyRequest userModifyRequest);
+    void modifyUserActivityInfos(List<UserActivityModifyRequest> activitiesModifyRequests);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserService.java
@@ -2,15 +2,13 @@ package org.sopt.makers.operation.user.service;
 
 import java.util.List;
 
-import org.sopt.makers.operation.user.dto.request.UserActivityModifyRequest;
 import org.sopt.makers.operation.user.dto.request.UserModifyRequest;
 import org.sopt.makers.operation.user.dto.response.UserInfoResponse;
 import org.sopt.makers.operation.user.dto.response.UserInfosResponse;
 
 public interface UserService {
-    UserInfoResponse getUserInfo(Long userId);
+    UserInfoResponse getUserInfo(long userId);
     UserInfosResponse getUserInfos(List<Long> userIds);
 
-    void modifyUserPersonalInfo(UserModifyRequest userModifyRequest);
-    void modifyUserActivityInfos(List<UserActivityModifyRequest> activitiesModifyRequests);
+    void modifyUserInfo(long userId, UserModifyRequest userModifyRequest);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserServiceImpl.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.sopt.makers.operation.user.dao.UserActivityInfoUpdateDao;
 import org.sopt.makers.operation.user.dao.UserPersonalInfoUpdateDao;
-import org.sopt.makers.operation.user.domain.Position;
 import org.sopt.makers.operation.user.domain.User;
 import org.sopt.makers.operation.user.domain.UserGenerationHistory;
 import org.sopt.makers.operation.user.dto.request.UserActivityModifyRequest;
@@ -80,8 +79,8 @@ public class UserServiceImpl implements UserService {
     private void validateIsAbleToUpdateActivity(
             UserGenerationHistory currentActivity, UserActivityModifyRequest activityModifyRequest
     ) {
-        if (!Position.MEMBER.equals(currentActivity.getPosition())
-                && !currentActivity.getTeam().equals(activityModifyRequest.team())
+        if (currentActivity.isExecutive()
+                && !currentActivity.isBelongTeamTo(activityModifyRequest.team())
         ) {
             throw new UserException(UserFailureCode.INVALID_USER_MODIFY_ACTIVITY_INFO);
         }

--- a/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/user/service/UserServiceImpl.java
@@ -34,7 +34,7 @@ public class UserServiceImpl implements UserService {
     private final UserGenerationHistoryRepository generationHistoryRepository;
 
     @Override
-    public UserInfoResponse getUserInfo(Long userId) {
+    public UserInfoResponse getUserInfo(final long userId) {
         validateIds(Collections.singletonList(userId));
         val targetUser = userRepository.findUserById(userId);
         val histories = generationHistoryRepository.findAllHistoryByUserId(userId);
@@ -42,7 +42,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserInfosResponse getUserInfos(List<Long> userIds) {
+    public UserInfosResponse getUserInfos(final List<Long> userIds) {
         validateIds(userIds);
         val targetUsers = userRepository.findAllUsersById(userIds);
         val userInfoResponses = targetUsers.stream()
@@ -52,19 +52,19 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void modifyUserPersonalInfo(UserModifyRequest userModifyRequest) {
-        val targetUser = userRepository.findUserById(userModifyRequest.userId());
+    public void modifyUserInfo(final long userId, final UserModifyRequest userModifyRequest) {
+        val targetUser = userRepository.findUserById(userId);
         val userInfoUpdateDao = new UserPersonalInfoUpdateDao(
                 userModifyRequest.userName(),
                 userModifyRequest.userPhone(),
                 userModifyRequest.userProfileImage()
         );
         targetUser.updateUserInfo(userInfoUpdateDao);
+
+        modifyUserActivityInfos(userModifyRequest.userActivities());
     }
 
-    @Override
-    @Transactional
-    public void modifyUserActivityInfos(List<UserActivityModifyRequest> activitiesModifyRequest) {
+    private void modifyUserActivityInfos(final List<UserActivityModifyRequest> activitiesModifyRequest) {
         activitiesModifyRequest.forEach(
                 activityModifyRequest -> {
                     val targetActivity = generationHistoryRepository.findHistoryById(activityModifyRequest.activityId());

--- a/operation-api/src/test/java/org/sopt/makers/operation/user/api/UserApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/user/api/UserApiControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.sopt.makers.operation.common.util.PermissionValidator;
 import org.sopt.makers.operation.user.domain.User;
 import org.sopt.makers.operation.user.domain.Part;
 import org.sopt.makers.operation.user.domain.Team;
@@ -65,6 +66,9 @@ class UserApiControllerTest {
     JwtTokenProvider tokenProvider;
     @MockBean
     CommonUtils commonUtils;
+
+    @MockBean
+    PermissionValidator permissionValidator;
 
     @Autowired
     MockMvc mockMvc;

--- a/operation-api/src/test/java/org/sopt/makers/operation/user/service/UserServiceTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/user/service/UserServiceTest.java
@@ -82,17 +82,6 @@ class UserServiceTest {
     @DisplayName("[TEST] 실패한 경우에 대한 테스트")
     class FailureTest {
 
-        @Test
-        @DisplayName("Case. 단일 유저 조회 시에 null이 주입할 경우, 예외 반환")
-        void throwException_Null_Id() {
-            // given
-            Long invalidUserId = null;
-
-            // when & then
-            assertThatThrownBy(() -> userService.getUserInfo(invalidUserId))
-                    .isInstanceOf(UserException.class)
-                    .hasMessageContaining(UserFailureCode.INVALID_PARAMETER.getMessage());
-        }
 
         @Test
         @DisplayName("Case. 복수 유저 조회 시에 빈 Id 리스트를 주입할 경우, 예외 반환")

--- a/operation-api/src/test/java/org/sopt/makers/operation/user/service/UserServiceTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/user/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package org.sopt.makers.operation.user.service;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Collections;
+import java.util.stream.Stream;
 
 import lombok.val;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.InjectMocks;
@@ -18,11 +21,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.sopt.makers.operation.code.failure.UserFailureCode;
 import org.sopt.makers.operation.exception.UserException;
+import org.sopt.makers.operation.user.domain.*;
+import org.sopt.makers.operation.user.dto.request.UserActivityModifyRequest;
 import org.sopt.makers.operation.user.dto.response.UserInfoResponse;
-import org.sopt.makers.operation.user.domain.User;
-import org.sopt.makers.operation.user.domain.Team;
-import org.sopt.makers.operation.user.domain.Position;
-import org.sopt.makers.operation.user.domain.UserGenerationHistory;
 import org.sopt.makers.operation.user.repository.UserRepository;
 import org.sopt.makers.operation.user.repository.history.UserGenerationHistoryRepository;
 
@@ -47,8 +48,8 @@ class UserServiceTest {
     class SuccessTest {
 
         @Test
-        @DisplayName("Case1. 의도했던 데이터로 구성된 Response 데이터가 반환된다.")
-        void expectResponseReturnSuccess() {
+        @DisplayName("Case. 의도했던 데이터로 구성된 유저 조회 결과 Response 데이터가 반환된다.")
+        void expectFindUserResponseReturnSuccess() {
             // given
             User mockedUser = mock(User.class);
             UserGenerationHistory mockedHistory = mock(UserGenerationHistory.class);
@@ -91,6 +92,7 @@ class UserServiceTest {
                     .isInstanceOf(UserException.class)
                     .hasMessageContaining(UserFailureCode.INVALID_PARAMETER.getMessage());
         }
+
         @Test
         @DisplayName("Case. 복수 유저 조회 시에 빈 Id 리스트를 주입할 경우, 예외 반환")
         void throwException_Empty_Ids() {
@@ -125,6 +127,32 @@ class UserServiceTest {
                     .hasMessageContaining(UserFailureCode.INVALID_USER_IN_USER_LIST_PARAMETER.getMessage());
         }
 
-    }
+        @ParameterizedTest
+        @DisplayName("Case. 유저 활동 데이터 변경 시에 임원진이면서 기존 저장되어 있던 Team과 다를 경우")
+        @MethodSource("ofActivityUpdateRequests")
+        void throwException_Update_Team_Data_Of_Executive_User(
+                // given
+                List<UserActivityModifyRequest> activitiesModifyRequest
+        ) {
+            UserGenerationHistory mockedExistHistory = mock(UserGenerationHistory.class);
+            given(mockedExistHistory.getTeam()).willReturn(Team.MAKERS);
+            given(mockedExistHistory.getPosition()).willReturn(Position.TEAM_LEADER);
 
+            given(userGenerationHistoryRepository.findHistoryById(1L)).willReturn(mockedExistHistory);
+
+            // then
+            assertThatThrownBy(() -> userService.modifyUserActivityInfos(activitiesModifyRequest))
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserFailureCode.INVALID_USER_MODIFY_ACTIVITY_INFO.getMessage());
+        }
+        static Stream<Arguments> ofActivityUpdateRequests() {
+            return Stream.of(
+                    Arguments.of(
+                            List.of(
+                                    new UserActivityModifyRequest(1L, 34, Part.SERVER, Team.OPERATION, Position.TEAM_LEADER)
+                            )
+                    )
+            );
+        }
+    }
 }

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/PermissionFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/PermissionFailureCode.java
@@ -1,0 +1,18 @@
+package org.sopt.makers.operation.code.failure;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PermissionFailureCode implements FailureCode {
+    // 403
+    NO_PERMISSION_ONLY_SELF(HttpStatus.FORBIDDEN, "해당 API는 본인만 요청할 수 있습니다."),
+    NO_PERMISSION_ONLY_SELF_INCLUDE_EXECUTIVE(HttpStatus.FORBIDDEN, "해당 API는 본인 포함 임원진까지만 요청할 수 있습니다."),
+
+    ;
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/UserFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/UserFailureCode.java
@@ -14,6 +14,7 @@ public enum UserFailureCode implements FailureCode{
     // 400
     INVALID_PARAMETER(BAD_REQUEST, "잘못된 형식의 회원 정보 요청입니다."),
     INVALID_USER_IN_USER_LIST_PARAMETER(BAD_REQUEST, "유효하지 않은 회원 ID가 포함되어 있습니다."),
+    INVALID_USER_MODIFY_ACTIVITY_INFO(BAD_REQUEST, "유효하지 않은 활동 이력 변경 요청입니다."),
 
     // 404
     NOT_FOUND_USER(NOT_FOUND, "존재하지 않는 회원입니다."),

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/success/UserSuccessCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/success/UserSuccessCode.java
@@ -5,12 +5,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 @Getter
 @RequiredArgsConstructor
 public enum UserSuccessCode implements SuccessCode {
+
+    // 200
     SUCCESS_GET_USER(OK, "유저 정보 조회 성공"),
     SUCCESS_GET_USERS(OK, "전체 유저 정보 조회 성공"),
+
+    // 204
+    SUCCESS_PUT_USER(NO_CONTENT, "유저 정보 수정 성공")
     ;
 
     private final HttpStatus status;

--- a/operation-common/src/main/java/org/sopt/makers/operation/exception/PermissionException.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/exception/PermissionException.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.operation.exception;
+
+import lombok.Getter;
+import org.sopt.makers.operation.code.failure.FailureCode;
+
+@Getter
+public class PermissionException extends RuntimeException {
+
+    private final FailureCode failureCode;
+
+    public PermissionException(FailureCode failureCode) {
+        super("[PermissionException] : " + failureCode.getMessage());
+        this.failureCode = failureCode;
+    }
+
+}

--- a/operation-domain/build.gradle
+++ b/operation-domain/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // db
-    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
 
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind
@@ -28,4 +27,5 @@ dependencies {
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/dao/UserActivityInfoUpdateDao.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/dao/UserActivityInfoUpdateDao.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.operation.user.dao;
+
+import org.sopt.makers.operation.user.domain.Team;
+
+public record UserActivityInfoUpdateDao(
+    Team team
+) {
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/dao/UserPersonalInfoUpdateDao.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/dao/UserPersonalInfoUpdateDao.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.operation.user.dao;
+
+public record UserPersonalInfoUpdateDao(
+    String name,
+    String phone,
+    String profileImage
+) {
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/Part.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/Part.java
@@ -7,6 +7,6 @@ public enum Part {
     WEB,
     ANDROID,
     IOS,
-    SERVER
-
+    SERVER,
+    INDEPENDENT, // 회장단 무소속 선택지
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/Team.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/Team.java
@@ -2,5 +2,6 @@ package org.sopt.makers.operation.user.domain;
 
 public enum Team {
     OPERATION,
-    MEDIA
+    MEDIA,
+    MAKERS
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/User.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/User.java
@@ -17,12 +17,15 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.AccessLevel;
 
+import org.hibernate.annotations.DynamicUpdate;
 import org.sopt.makers.operation.common.domain.BaseEntity;
+import org.sopt.makers.operation.user.dao.UserPersonalInfoUpdateDao;
 
 @Entity @Getter
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@DynamicUpdate
 public class User extends BaseEntity {
 
     @Id
@@ -57,5 +60,11 @@ public class User extends BaseEntity {
         this.name = name;
         this.profileImage = profileImage;
         this.birthday = birthday;
+    }
+
+    public void updateUserInfo(UserPersonalInfoUpdateDao infoUpdateDao) {
+        this.name = infoUpdateDao.name();
+        this.phone = infoUpdateDao.phone();
+        this.profileImage = infoUpdateDao.profileImage();
     }
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/User.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/User.java
@@ -17,7 +17,6 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.AccessLevel;
 
-import org.hibernate.annotations.DynamicUpdate;
 import org.sopt.makers.operation.common.domain.BaseEntity;
 import org.sopt.makers.operation.user.dao.UserPersonalInfoUpdateDao;
 
@@ -25,7 +24,6 @@ import org.sopt.makers.operation.user.dao.UserPersonalInfoUpdateDao;
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@DynamicUpdate
 public class User extends BaseEntity {
 
     @Id

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/UserGenerationHistory.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/UserGenerationHistory.java
@@ -53,6 +53,14 @@ public class UserGenerationHistory {
         this.position = position;
     }
 
+    public boolean isExecutive() {
+        return !Position.MEMBER.equals(this.position);
+    }
+
+    public boolean isBelongTeamTo(Team team) {
+        return this.team.equals(team);
+    }
+
     public void updateActivityInfo(UserActivityInfoUpdateDao activityInfoUpdateDao) {
         this.team = activityInfoUpdateDao.team();
     }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/UserGenerationHistory.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/UserGenerationHistory.java
@@ -14,11 +14,14 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.AccessLevel;
+import org.hibernate.annotations.DynamicUpdate;
+import org.sopt.makers.operation.user.dao.UserActivityInfoUpdateDao;
 
 @Entity @Getter
 @Table(name = "user_generation_history")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@DynamicUpdate
 public class UserGenerationHistory {
 
     @Id
@@ -50,5 +53,9 @@ public class UserGenerationHistory {
         this.part = part;
         this.team = team;
         this.position = position;
+    }
+
+    public void updateActivityInfo(UserActivityInfoUpdateDao activityInfoUpdateDao) {
+        this.team = activityInfoUpdateDao.team();
     }
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/UserGenerationHistory.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/domain/UserGenerationHistory.java
@@ -14,14 +14,12 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.AccessLevel;
-import org.hibernate.annotations.DynamicUpdate;
 import org.sopt.makers.operation.user.dao.UserActivityInfoUpdateDao;
 
 @Entity @Getter
 @Table(name = "user_generation_history")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@DynamicUpdate
 public class UserGenerationHistory {
 
     @Id

--- a/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/history/UserGenerationHistoryRepository.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/user/repository/history/UserGenerationHistoryRepository.java
@@ -15,6 +15,10 @@ public interface UserGenerationHistoryRepository extends JpaRepository<UserGener
 
     List<UserGenerationHistory> findAllByUserId(Long userId);
 
+    default UserGenerationHistory findHistoryById(Long historyId) {
+        return findById(historyId).orElseThrow(() -> new UserException(UserFailureCode.NOT_FOUND_HISTORY));
+    }
+
     default List<UserGenerationHistory> findAllHistoryByUserId(Long userId) {
         val histories = findAllByUserId(userId);
         if (histories.isEmpty()) {

--- a/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
@@ -4,30 +4,36 @@ import lombok.val;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import org.sopt.makers.operation.DatabaseCleaner;
 import org.sopt.makers.operation.user.domain.User;
 import org.sopt.makers.operation.user.domain.Gender;
 import org.sopt.makers.operation.user.repository.history.UserGenerationHistoryRepository;
+import org.sopt.makers.operation.user.dao.UserPersonalInfoUpdateDao;
+import org.sopt.makers.operation.DatabaseCleaner;
 import org.sopt.makers.operation.exception.UserException;
 import org.sopt.makers.operation.code.failure.UserFailureCode;
 
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,11 +43,14 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle;
 @DisplayName("[[ Unit Test ]] - UserRepository")
 @EntityScan(basePackages = "org.sopt.makers.operation.user")
 @ContextConfiguration(classes = {
-        UserRepository.class, UserGenerationHistoryRepository.class, DatabaseCleaner.class
+        UserRepository.class, UserGenerationHistoryRepository.class,
+        DatabaseCleaner.class
 })
 @EnableAutoConfiguration
-@ActiveProfiles("domain-unit")
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class UserRepositoryTest {
+
     @Autowired
     private UserRepository userRepository;
 
@@ -52,15 +61,15 @@ class UserRepositoryTest {
     @DisplayName("[TEST] 단일 유저 대상 단일 ID로 조회하는 시나리오")
     @TestInstance(Lifecycle.PER_CLASS)
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-    class SingleUserTest {
+    class SingleUserSelectTest {
 
         @BeforeAll
         void setUpCleanerProperties() {
-            cleaner.afterPropertiesSet();
             cleaner.execute();
         }
 
         private User user;
+
         @BeforeEach
         void setUpSingleUser() {
             User userEntity = User.builder()
@@ -75,7 +84,6 @@ class UserRepositoryTest {
         }
 
         @Test
-        @Order(1)
         @DisplayName("Case1. 단일 유저에 대한 조회 성공")
         void getSuccessTest() {
             // given
@@ -95,7 +103,6 @@ class UserRepositoryTest {
         }
 
         @Test
-        @Order(2)
         @DisplayName("Case2. 존재하지 않은 userId일 경우, 예외 반환")
         void getFailTest() {
             // given
@@ -112,14 +119,12 @@ class UserRepositoryTest {
     @Nested
     @TestInstance(Lifecycle.PER_CLASS)
     @DisplayName("[TEST] 여러 유저가 저장된 상태에서 단일 ID로 조회하는 시나리오")
-    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-    class MultiUserTest {
+    class MultiUserSelectTest {
 
         List<User> users;
 
         @BeforeAll
         void setUpMultiUser() {
-            cleaner.afterPropertiesSet();
             cleaner.execute();
             User userA = User.builder()
                     .email("test1@test.com")
@@ -153,9 +158,11 @@ class UserRepositoryTest {
         void getSuccessTest() {
             // given
             val ids = List.of(1L, 2L, 3L);
-
+            List<User> allUser = userRepository.findAll();
+            allUser.forEach(u -> System.out.println(u.getId()));
             // when
             val result = userRepository.findAllUsersById(ids);
+
 
             // then
             assertThat(users).usingRecursiveComparison()
@@ -172,6 +179,112 @@ class UserRepositoryTest {
             assertThatThrownBy(() -> userRepository.findAllUsersById(ids))
                     .isInstanceOf(UserException.class)
                     .hasMessageContaining(UserFailureCode.NOT_FOUND_USER_IN_USER_LIST_PARAMETER.getMessage());
+        }
+
+    }
+
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    @DisplayName("[TEST] 단일 유저 정보 수정하는 시나리오")
+    class SingleUserUpdateTest {
+
+        private static final long ABSOLUTE_USER_ID_VALUE = 1L;
+
+        private User user;
+
+        @BeforeEach
+        void setUpUser() {
+            cleaner.afterPropertiesSet();
+            cleaner.execute();
+            User userEntity = User.builder()
+                    .email("test@test.com")
+                    .gender(Gender.MALE)
+                    .phone("010-0000-0000")
+                    .name("TestUser")
+                    .profileImage("DummyImageUrl")
+                    .birthday(LocalDate.of(1999, 12,4))
+                    .build();
+            user = userRepository.save(userEntity);
+        }
+
+        @ParameterizedTest
+        @DisplayName("Case. 단일 유저에 대한 전체 데이터 변경 성공")
+        @MethodSource("ofAllDataUpdate")
+        @Rollback(value = false)
+        void updateAllDataSuccess(
+                UserPersonalInfoUpdateDao infoUpdateDao,
+                String expectedName,
+                String expectedPhone,
+                String expectedProfileImageUrl
+        ) {
+            // given
+            User targetUser = userRepository.findUserById(ABSOLUTE_USER_ID_VALUE);
+
+            // when
+            targetUser.updateUserInfo(infoUpdateDao);
+            userRepository.save(user);
+            User expectedUser = userRepository.findUserById(ABSOLUTE_USER_ID_VALUE);
+
+            // then
+            assertThat(expectedUser.getName()).isEqualTo(expectedName);
+            assertThat(expectedUser.getPhone()).isEqualTo(expectedPhone);
+            assertThat(expectedUser.getProfileImage()).isEqualTo(expectedProfileImageUrl);
+        }
+        static Stream<Arguments> ofAllDataUpdate(){
+            return Stream.of(
+                    Arguments.of(
+                            new UserPersonalInfoUpdateDao("김철수", "01098765432", "changedProfileImageForCheolSu"),
+                            "김철수", "01098765432", "changedProfileImageForCheolSu"
+                    ),
+                    Arguments.of(
+                            new UserPersonalInfoUpdateDao("장민수", "01013245768", "changedProfileImageForMinsu"),
+                            "장민수", "01013245768", "changedProfileImageForMinsu"
+                    ),
+                    Arguments.of(
+                            new UserPersonalInfoUpdateDao("조진세", "01097865342", "changedProfileImageForJinsae"),
+                            "조진세", "01097865342", "changedProfileImageForJinsae"
+                    )
+            );
+        }
+
+        @ParameterizedTest
+        @DisplayName("Case. 단일 유저에 대한 부분 데이터 변경 성공")
+        @MethodSource("ofPartialDataUpdate")
+        @Rollback(value = false)
+        void updatePartialDataSuccess(
+                UserPersonalInfoUpdateDao infoUpdateDao,
+                String expectedName,
+                String expectedPhone,
+                String expectedProfileImageUrl
+        ) {
+            // given
+            User targetUser = userRepository.findUserById(ABSOLUTE_USER_ID_VALUE);
+
+            // when
+            targetUser.updateUserInfo(infoUpdateDao);
+            userRepository.save(user);
+            User expectedUser = userRepository.findUserById(ABSOLUTE_USER_ID_VALUE);
+
+            // then
+            assertThat(expectedUser.getName()).isEqualTo(expectedName);
+            assertThat(expectedUser.getPhone()).isEqualTo(expectedPhone);
+            assertThat(expectedUser.getProfileImage()).isEqualTo(expectedProfileImageUrl);
+        }
+        static Stream<Arguments> ofPartialDataUpdate(){
+            return Stream.of(
+                    Arguments.of(
+                            new UserPersonalInfoUpdateDao("김철수", "010-0000-0000", "DummyImageUrl"),
+                            "김철수", "010-0000-0000", "DummyImageUrl"
+                    ),
+                    Arguments.of(
+                            new UserPersonalInfoUpdateDao("TestUser", "010-1324-5768", "DummyImageUrl"),
+                            "TestUser", "010-1324-5768", "DummyImageUrl"
+                    ),
+                    Arguments.of(
+                            new UserPersonalInfoUpdateDao("TestUser", "010-0000-0000", "changedProfileImage"),
+                            "TestUser", "010-0000-0000", "changedProfileImage"
+                    )
+            );
         }
 
     }

--- a/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
@@ -222,7 +222,6 @@ class UserRepositoryTest {
 
             // when
             targetUser.updateUserInfo(infoUpdateDao);
-            userRepository.save(user);
             User expectedUser = userRepository.findUserById(ABSOLUTE_USER_ID_VALUE);
 
             // then

--- a/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/user/repository/UserRepositoryTest.java
@@ -235,14 +235,6 @@ class UserRepositoryTest {
                     Arguments.of(
                             new UserPersonalInfoUpdateDao("김철수", "01098765432", "changedProfileImageForCheolSu"),
                             "김철수", "01098765432", "changedProfileImageForCheolSu"
-                    ),
-                    Arguments.of(
-                            new UserPersonalInfoUpdateDao("장민수", "01013245768", "changedProfileImageForMinsu"),
-                            "장민수", "01013245768", "changedProfileImageForMinsu"
-                    ),
-                    Arguments.of(
-                            new UserPersonalInfoUpdateDao("조진세", "01097865342", "changedProfileImageForJinsae"),
-                            "조진세", "01097865342", "changedProfileImageForJinsae"
                     )
             );
         }
@@ -262,7 +254,7 @@ class UserRepositoryTest {
 
             // when
             targetUser.updateUserInfo(infoUpdateDao);
-            userRepository.save(user);
+            userRepository.save(targetUser);
             User expectedUser = userRepository.findUserById(ABSOLUTE_USER_ID_VALUE);
 
             // then


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #276 
- closes T-10859

## Work Description ✏️
> 기능
- Request Body 내 User ID에 해당하는 단일 유저에 대한 정보를 변경하는 API입니다.
- Repository 레이어 & Service 레이어에 대한 Unit Test 또한 수행했습니다.
  - Service Layer : Exception 발생 여부 확인
  - Repository(Domain) Layer : `@Dynamic Update` 정상 적용 여부 & 정상 데이터 수정 반영 여부
    - `@Dynamic Update` 정상 적용 여부의 경우, `application-test.yml` 내 `logging.level.org.hibernate.SQL.DEBUG`로 설정하여 동적 쿼리 생성 여부를 확인하는 방식으로 진행했습니다.

<br/>

> 빌드/배포
- CI/CD Script Step이 추가되었습니다.
  - CI 및 CD 과정에서 Test YAML 파일 생성 Step을 추가했습니다.
  - Domain Test에서 사용되는 DB 환경을 분리하기 위해 `@Profile`을 통해 특정 profile에 해당하는 yaml 파일을 활용하여 테스트가 빌드되도록 설정했습니다.
  - 빌드 과정에서 `application-test.yml` 파일을 생성하여
  - `application-test.yml`의 경우, 본 `sopt-operation-backend` 레포 Actions Secret 값으로 추가해두었습니다.
    - [노션](https://www.notion.so/sopt-makers/application-test-yml-8f6451d741cb4a23bc537d9c495e615f?pvs=4)에 파일 공유 완료했습니다.

<br/>
<br/>

# PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
## 🤔 고민한 점 & 알게된 점 & 궁금한 점
### 0️⃣ 서로 다른 public 메서드 분리 및 별도 처리 ←→ 단일 Service 메서드 내에서 private 메서드로 분리
> User Service 객체의 **유저 정보 수정 메서드**를 정의하는 과정에서 발생한 고민점입니다.

1. Service 객체 내 `UserPersonalInfo` Update `Public` Method & `UserActivityInfo` Update `Public` Method 분리 정의 및 구현 <br/>(Controller 단에서는 Update `Public` Method 둘 다 호출) <br/><br/>
2. Service 객체 내 `UserInfo` Update `Public` Method 구현 & 해당 Method 내부에서 사용할 `UserPersonalInfo` & `UserActivityInfo` Update `Private` Method 분리 구현 <br/>(Controller 단에서는 `UserInfo` Update `Public` Method 하나만 호출) 

#### [현재 구현 채택]
Service 객체 내 `UserInfo` Update `Public` Method 구현 & 해당 Method 내부에서 사용할 `UserPersonalInfo` & `UserActivityInfo` Update `Private` Method 분리 구현 <br/>(Controller 단에서는 `UserInfo` Update `Public` Method 하나만 호출) 

#### [이유]
1. Controller 단에서의 별도 각 분리된 기능 메서드를 호출함으로서 해당 API에서 어떤 로직들이 처리되는지에 대한 내용 구체적으로 전달하기 위해서
2. Service 객체에서 각 각의 기능 메서드는 단 하나의 관심사에 대해서만 처리하도록 하기 위해서

<br/>

### 1️⃣ PathVariable이 아닌 Request Body를 통한 변경 대상 정보 전달
> API 스펙 설계하는 과정에서 발생한 고민점입니다.

_(해당 내용은 RESTful API 규칙을 기반으로 PathVariable로 요청 자원에 대한 정보를 전달 받는 방식으로 결정했습니다.)_

<br/>

### 2️⃣ Build Profile 분리를

H2 Database의 In-Memory Mode를 활용하여
분리된 테스트 환경에서만 사용되고 데이터가 사라지도록 하는 선택지를 채택했습니다.
("**메모리에 임시로 저장하고 테스트 종료 후, 데이터는 저장되지 않는다**"는 점과 "**빠른 실행이 가능**하다"는 장점이 있습니다.)

이를 위해 Gradle 파일 내에 test Implementation으로 H2 DB 의존성을 추가했습니다.
또한 Domain Test Class에 `@Profile("test")` 어노테이션으로 적용하는 설정 파일의 profile까지 지정하여 테스트 환경을 분리했습니다!

물론 기존 `application.yml` 파일에서 profile을 분리하여 값들을 설정할 수 있지만
Test에 사용되는 resource 파일은 내용과 패키지를 따로 분리하여 관리하는 것이 편리하고 보다 안전할 것이라고 생각하여
`application-test.yml` 파일을 별도로 생성 & `domain` 모듈 내 `test/resources` 패키지에 생성되도록 설정했습니다.

> **해당 작업에 대한 우려점과 궁금증 있으시면 편하게 댓글 달아주세요!!**

#### ※ 전에 블로그를 살펴보다가 고민해보고 공부하면 좋을 것 같은 댓글이 있어 첨부합니다! <br/> [실무에서 적용하는 테스트 코드 작성 방법과 노하우 Part 3: Given 지옥에서 벗어나기 - 객체 기반 데이터 셋업의 한계](https://tech.kakaopay.com/post/given-test-code/)

<br/>

### 3️⃣ DAO 객체 도입
도메인 필드 값 변경 메서드에서
필드 값이 많은 경우에 대해 일괄적으로 값을 객체를 통해 주입하는 방식을 채택했습니다.

**<DAO 객체 도입 이유>**
- 변경되는 필드가 적든 많든 Hibernate에 의해 caching 되어있는 UPDATE 쿼리의 경우, 모든 필드에 대한 변경 쿼리문이 형성됩니다.
- 필드를 모두 메서드 파라미터로 주입 받게되는 경우, 하나의 메서드에 지나치게 많은 파라미터 선언이 필요하게 됩니다.
  - 이를 대비하고자 필드 하나하나에 대한 변경 메서드를 선언하는 것은 더욱 비효율적입니다.(호출할 때마다 UPDATE 쿼리 발생)


<br/>