### PR TITLE
[FEAT/#290] 배너 삭제 & 외부 배너 조회 기능 구현

### DIFF
--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
@@ -31,4 +31,27 @@ public interface BannerApi {
     )
     ResponseEntity<BaseResponse<?>> getBannerDetail(Long bannerId);
 
+    @Operation(
+        summary = "배너 삭제 API",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "배너 삭제 성공"
+            ),
+            @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"
+            ),
+            @ApiResponse(
+                responseCode = "404",
+                description = "존재하지 않는 배너 ID 요청"
+            ),
+            @ApiResponse(
+                responseCode = "500",
+                description = "서버 내부 오류"
+            )
+        }
+    )
+  ResponseEntity<BaseResponse<?>> deleteBanner(Long bannerId);
+
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
@@ -54,4 +54,22 @@ public interface BannerApi {
     )
   ResponseEntity<BaseResponse<?>> deleteBanner(Long bannerId);
 
+  @Operation(
+      summary = "게시 중인 외부 배너 리스트 조회 API",
+      responses = {
+          @ApiResponse(
+              responseCode = "200",
+              description = "게시 중인 외부 배너 리스트 조회 성공"
+          ),
+          @ApiResponse(
+              responseCode = "400",
+              description = "잘못된 요청"
+          ),
+          @ApiResponse(
+              responseCode = "500",
+              description = "서버 내부 오류"
+          )
+      }
+  )
+  ResponseEntity<BaseResponse<?>> getExternalBanners(String platform, String location);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -3,9 +3,11 @@ package org.sopt.makers.operation.web.banner.api;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 
+import org.sopt.makers.operation.code.success.web.BannerSuccessCode;
 import org.sopt.makers.operation.dto.BaseResponse;
 import org.sopt.makers.operation.util.ApiResponseUtil;
 import org.sopt.makers.operation.web.banner.dto.request.BannerRequest;
+import org.sopt.makers.operation.web.banner.dto.request.BannerRequest.BannerCreate;
 import org.sopt.makers.operation.web.banner.service.BannerService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,60 +17,68 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_CREATE_BANNER;
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_DELETE_BANNER;
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_DETAIL;
+import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL;
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_EXTERNAL_BANNERS;
 
 import org.springframework.web.bind.annotation.*;
-
-import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_CREATE_BANNER;
-import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_DETAIL;
-import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL;
 
 @RestController
 @RequestMapping("/api/v1/banners")
 @RequiredArgsConstructor
 public class BannerApiController implements BannerApi {
-    private final BannerService bannerService;
 
-    @Override
-    @GetMapping("/{bannerId}")
-    public ResponseEntity<BaseResponse<?>> getBannerDetail(
-            @PathVariable("bannerId") Long bannerId
-    ) {
-        val response = bannerService.getBannerDetail(bannerId);
-        return ApiResponseUtil.success(SUCCESS_GET_BANNER_DETAIL, response);
-    }
+  private final BannerService bannerService;
 
-    @Override
-    @DeleteMapping("/{bannerId}")
-    public ResponseEntity<BaseResponse<?>> deleteBanner(
-        @PathVariable("bannerId") Long bannerId
-    ) {
-        bannerService.deleteBanner(bannerId);
-        return ApiResponseUtil.success(SUCCESS_DELETE_BANNER);
-    }
+  @Override
+  @GetMapping("/{bannerId}")
+  public ResponseEntity<BaseResponse<?>> getBannerDetail(
+      @PathVariable("bannerId") Long bannerId
+  ) {
+    val response = bannerService.getBannerDetail(bannerId);
+    return ApiResponseUtil.success(SUCCESS_GET_BANNER_DETAIL, response);
+  }
 
-    @Override
-    @GetMapping("/images")
-    public ResponseEntity<BaseResponse<?>> getExternalBanners(
-        @RequestParam("image_type") String imageType,
-        @RequestParam("location") String location
-    ) {
-      return ApiResponseUtil.success(SUCCESS_GET_EXTERNAL_BANNERS, bannerService.getExternalBanners(imageType, location));
+  @Override
+  @DeleteMapping("/{bannerId}")
+  public ResponseEntity<BaseResponse<?>> deleteBanner(
+      @PathVariable("bannerId") Long bannerId
+  ) {
+    bannerService.deleteBanner(bannerId);
+    return ApiResponseUtil.success(SUCCESS_DELETE_BANNER);
+  }
 
-    @Override
-    @GetMapping("/img/pre-signed")
-    public ResponseEntity<BaseResponse<?>> getIssuedPreSignedUrlForPutImage(@RequestParam("content-name") String contentName, @RequestParam("image-type") String imageType,
-                                                                            @RequestParam("image-extension") String imageExtension, @RequestParam("content-type") String contentType) {
-        val response = bannerService.getIssuedPreSignedUrlForPutImage(contentName, imageType, imageExtension, contentType);
-        return ApiResponseUtil.success(SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL, response);
-    }
+  @Override
+  @GetMapping("/images")
+  public ResponseEntity<BaseResponse<?>> getExternalBanners(
+      @RequestParam("image_type") String imageType,
+      @RequestParam("location") String location
+  ) {
+    return ApiResponseUtil.success(SUCCESS_GET_EXTERNAL_BANNERS,
+        bannerService.getExternalBanners(imageType, location));
+  }
 
-    @PostMapping
-    @Override
-    public ResponseEntity<BaseResponse<?>> createBanner(@RequestBody BannerRequest.BannerCreate request) {
-        val response = bannerService.createBanner(request);
-        return ApiResponseUtil.success(SUCCESS_CREATE_BANNER, response);
-    }
+  @Override
+  @GetMapping("/img/pre-signed")
+  public ResponseEntity<BaseResponse<?>> getIssuedPreSignedUrlForPutImage(
+      @RequestParam("content-name") String contentName,
+      @RequestParam("image-type") String imageType,
+      @RequestParam("image-extension") String imageExtension,
+      @RequestParam("content-type") String contentType
+  ) {
+      val response = bannerService.getIssuedPreSignedUrlForPutImage(contentName, imageType,
+        imageExtension, contentType);
+    return ApiResponseUtil.success(SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL, response);
+  }
+
+  @PostMapping
+  @Override
+  public ResponseEntity<BaseResponse<?>> createBanner(
+      @RequestBody BannerRequest.BannerCreate request
+  ) {
+    val response = bannerService.createBanner(request);
+    return ApiResponseUtil.success(SUCCESS_CREATE_BANNER, response);
+  }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_DELETE_BANNER;
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_DETAIL;
+import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_EXTERNAL_BANNERS;
 
 @RestController
 @RequestMapping("/api/v1/banners")
@@ -38,5 +40,14 @@ public class BannerApiController implements BannerApi {
     ) {
         bannerService.deleteBanner(bannerId);
         return ApiResponseUtil.success(SUCCESS_DELETE_BANNER);
+    }
+
+    @Override
+    @GetMapping("/images")
+    public ResponseEntity<BaseResponse<?>> getExternalBanners(
+        @RequestParam("platform") String platform,
+        @RequestParam("location") String location
+    ) {
+      return ApiResponseUtil.success(SUCCESS_GET_EXTERNAL_BANNERS, bannerService.getExternalBanners(platform, location));
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -45,9 +45,9 @@ public class BannerApiController implements BannerApi {
     @Override
     @GetMapping("/images")
     public ResponseEntity<BaseResponse<?>> getExternalBanners(
-        @RequestParam("platform") String platform,
+        @RequestParam("image_type") String imageType,
         @RequestParam("location") String location
     ) {
-      return ApiResponseUtil.success(SUCCESS_GET_EXTERNAL_BANNERS, bannerService.getExternalBanners(platform, location));
+      return ApiResponseUtil.success(SUCCESS_GET_EXTERNAL_BANNERS, bannerService.getExternalBanners(imageType, location));
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -7,11 +7,13 @@ import org.sopt.makers.operation.dto.BaseResponse;
 import org.sopt.makers.operation.util.ApiResponseUtil;
 import org.sopt.makers.operation.web.banner.service.BannerService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_DELETE_BANNER;
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_DETAIL;
 
 @RestController
@@ -27,5 +29,14 @@ public class BannerApiController implements BannerApi {
     ) {
         val response = bannerService.getBannerDetail(bannerId);
         return ApiResponseUtil.success(SUCCESS_GET_BANNER_DETAIL, response);
+    }
+
+    @Override
+    @DeleteMapping("/{bannerId}")
+    public ResponseEntity<BaseResponse<?>> deleteBanner(
+        @PathVariable("bannerId") Long bannerId
+    ) {
+        bannerService.deleteBanner(bannerId);
+        return ApiResponseUtil.success(SUCCESS_DELETE_BANNER);
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/response/BannerResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/response/BannerResponse.java
@@ -1,6 +1,8 @@
 package org.sopt.makers.operation.web.banner.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.operation.banner.domain.Banner;
@@ -37,6 +39,18 @@ public final class BannerResponse {
                     .pcImageUrl(banner.getImage().getPcImageUrl())
                     .mobileImageUrl(banner.getImage().getMobileImageUrl())
                     .build();
+        }
+
+
+    }
+    public record BannerImageUrl(
+        @JsonProperty("url") String url
+    ){
+
+        public static List<BannerImageUrl> fromEntity(List<String> urlList){
+            return urlList.stream()
+                .map(BannerImageUrl::new)
+                .collect(Collectors.toUnmodifiableList());
         }
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
@@ -1,10 +1,15 @@
 package org.sopt.makers.operation.web.banner.service;
 
+import java.util.List;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
+import org.sopt.makers.operation.web.banner.dto.response.BannerResponse.BannerDetail;
+import org.sopt.makers.operation.web.banner.dto.response.BannerResponse.BannerImageUrl;
 
 public interface BannerService {
 
     BannerResponse.BannerDetail getBannerDetail(final long bannerId);
 
     void deleteBanner(final long bannerId);
+
+    List<BannerImageUrl> getExternalBanners(final String platform, final String location);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
@@ -5,4 +5,6 @@ import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
 public interface BannerService {
 
     BannerResponse.BannerDetail getBannerDetail(final long bannerId);
+
+    void deleteBanner(final long bannerId);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -1,8 +1,11 @@
 package org.sopt.makers.operation.web.banner.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.makers.operation.banner.domain.Banner;
+import org.sopt.makers.operation.banner.domain.PublishLocation;
 import org.sopt.makers.operation.banner.repository.BannerRepository;
 import org.sopt.makers.operation.code.failure.BannerFailureCode;
 import org.sopt.makers.operation.exception.BannerException;
@@ -22,12 +25,25 @@ public class BannerServiceImpl implements BannerService {
     }
 
     @Override
-    public void deleteBanner(long bannerId) {
+    public void deleteBanner(final long bannerId) {
         val banner = getBannerById(bannerId);
         bannerRepository.delete(banner);
     }
 
-    private Banner getBannerById(final long id) {
+  @Override
+  public List<BannerResponse.BannerImageUrl> getExternalBanners(final String platform, final String location) {
+     PublishLocation publishLocation = PublishLocation.getByValue(location);
+
+     val bannerList = bannerRepository.findBannersByLocation(publishLocation);
+
+     List<String> list = bannerList.stream()
+         .map( banner -> banner.getImage().retrieveImageUrl(platform))
+         .collect(Collectors.toUnmodifiableList());
+
+    return BannerResponse.BannerImageUrl.fromEntity(list);
+  }
+
+  private Banner getBannerById(final long id) {
         return bannerRepository.findById(id)
                 .orElseThrow(() -> new BannerException(BannerFailureCode.NOT_FOUNT_BANNER));
     }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -21,6 +21,12 @@ public class BannerServiceImpl implements BannerService {
         return BannerResponse.BannerDetail.fromEntity(banner);
     }
 
+    @Override
+    public void deleteBanner(long bannerId) {
+        val banner = getBannerById(bannerId);
+        bannerRepository.delete(banner);
+    }
+
     private Banner getBannerById(final long id) {
         return bannerRepository.findById(id)
                 .orElseThrow(() -> new BannerException(BannerFailureCode.NOT_FOUNT_BANNER));

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -31,13 +31,13 @@ public class BannerServiceImpl implements BannerService {
     }
 
   @Override
-  public List<BannerResponse.BannerImageUrl> getExternalBanners(final String platform, final String location) {
-     PublishLocation publishLocation = PublishLocation.getByValue(location);
+  public List<BannerResponse.BannerImageUrl> getExternalBanners(final String imageType, final String location) {
+     val publishLocation = PublishLocation.getByValue(location);
 
      val bannerList = bannerRepository.findBannersByLocation(publishLocation);
 
      List<String> list = bannerList.stream()
-         .map( banner -> banner.getImage().retrieveImageUrl(platform))
+         .map( banner -> banner.getImage().retrieveImageUrl(imageType))
          .collect(Collectors.toUnmodifiableList());
 
     return BannerResponse.BannerImageUrl.fromEntity(list);

--- a/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
@@ -100,4 +100,23 @@ class BannerApiControllerTest {
                 .andExpect(jsonPath("$.success").value("true"));
 
     }
+
+    @Test
+    @DisplayName("(GET) External Banners")
+    void getExternalBanners() throws Exception {
+        // given
+        String platform = "pc";
+        String location = "pg_community";
+
+        this.mockMvc.perform(
+                        // when
+                        get("/api/v1/banners/images")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .param("platform", platform)
+                                .param("location", location)
+                                .principal(mock(Principal.class)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value("true"));
+    }
 }

--- a/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
@@ -105,14 +105,14 @@ class BannerApiControllerTest {
     @DisplayName("(GET) External Banners")
     void getExternalBanners() throws Exception {
         // given
-        String platform = "pc";
+        String imageType = "pc";
         String location = "pg_community";
 
         this.mockMvc.perform(
                         // when
                         get("/api/v1/banners/images")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .param("platform", platform)
+                                .param("platform", imageType)
                                 .param("location", location)
                                 .principal(mock(Principal.class)))
                 // then

--- a/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -66,7 +67,7 @@ class BannerApiControllerTest {
         this.mockMvc.perform(
                         // when
                         get("/api/v1/banners/" + MOCK_BANNER_ID)
-                                .contentType(MediaType.APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
                                 .principal(mock(Principal.class)))
                 // then
                 .andExpect(status().isOk())
@@ -93,7 +94,7 @@ class BannerApiControllerTest {
         this.mockMvc.perform(
             //when
             delete("/api/v1/banners/" + MOCK_BANNER_ID)
-                .contentType(MediaType.APPLICATION_JSON)
+                .contentType(APPLICATION_JSON)
                 .principal(mock(Principal.class)))
 
             //then
@@ -112,8 +113,8 @@ class BannerApiControllerTest {
         this.mockMvc.perform(
                         // when
                         get("/api/v1/banners/images")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .param("platform", imageType)
+                                .contentType(APPLICATION_JSON)
+                                .param("image_type", imageType)
                                 .param("location", location)
                                 .principal(mock(Principal.class)))
                 // then

--- a/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -80,5 +81,23 @@ class BannerApiControllerTest {
                 .andExpect(jsonPath("$.data.end_date").value(givenBannerDetail.endDate().toString()))
                 .andExpect(jsonPath("$.data.image_url_pc").value(givenBannerDetail.pcImageUrl()))
                 .andExpect(jsonPath("$.data.image_url_mobile").value(givenBannerDetail.mobileImageUrl()));
+    }
+
+    @Test
+    @DisplayName("(DELETE) Banner Delete")
+    void deleteBanner() throws Exception {
+        //given
+        BannerResponse.BannerDetail mockBannerDetail =  bannerService.getBannerDetail(MOCK_BANNER_ID);
+
+        this.mockMvc.perform(
+            //when
+            delete("/api/v1/banners/" + MOCK_BANNER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .principal(mock(Principal.class)))
+
+            //then
+                .andExpect(status().isNoContent())
+                .andExpect(jsonPath("$.success").value("true"));
+
     }
 }

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
@@ -13,6 +13,7 @@ public enum BannerFailureCode implements FailureCode {
     NOT_FOUND_LOCATION(NOT_FOUND, "존재하지 않는 게시 위치입니다."),
     NOT_FOUND_CONTENT_TYPE(NOT_FOUND, "존재하지 않는 게시 유형입니다."),
     NOT_FOUNT_BANNER(NOT_FOUND, "존재하지 않는 배너입니다."),
+    NOT_SUPPORTED_PLATFORM_TYPE(NOT_FOUND, "지원하지 않는 플랫폼 유형입니다."),
     ;
 
     private final HttpStatus status;

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
@@ -12,7 +12,7 @@ import static lombok.AccessLevel.PRIVATE;
 public enum BannerSuccessCode implements SuccessCode {
     SUCCESS_GET_BANNER_DETAIL(HttpStatus.OK, "배너 상세 정보 조회 성공"),
     SUCCESS_DELETE_BANNER(HttpStatus. NO_CONTENT, "배너 삭제 성공"),
-    SUCCESS_GET_EXTERNAL_BANNERS(HttpStatus.OK, "외부 배너 조회 성공")
+    SUCCESS_GET_EXTERNAL_BANNERS(HttpStatus.OK, "외부 배너 조회 성공"),
     SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL(HttpStatus.OK, "이미지 업로드 pre signed url 조회에 성공했습니다"),
     SUCCESS_CREATE_BANNER(HttpStatus.CREATED, "배너 생성에 성공했습니다")
     ;

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
@@ -11,6 +11,7 @@ import static lombok.AccessLevel.PRIVATE;
 @RequiredArgsConstructor(access = PRIVATE)
 public enum BannerSuccessCode implements SuccessCode {
     SUCCESS_GET_BANNER_DETAIL(HttpStatus.OK, "배너 상세 정보 조회 성공"),
+    SUCCESS_DELETE_BANNER(HttpStatus. NO_CONTENT, "배너 삭제 성공")
     ;
 
     private final HttpStatus status;

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
@@ -11,7 +11,8 @@ import static lombok.AccessLevel.PRIVATE;
 @RequiredArgsConstructor(access = PRIVATE)
 public enum BannerSuccessCode implements SuccessCode {
     SUCCESS_GET_BANNER_DETAIL(HttpStatus.OK, "배너 상세 정보 조회 성공"),
-    SUCCESS_DELETE_BANNER(HttpStatus. NO_CONTENT, "배너 삭제 성공")
+    SUCCESS_DELETE_BANNER(HttpStatus. NO_CONTENT, "배너 삭제 성공"),
+    SUCCESS_GET_EXTERNAL_BANNERS(HttpStatus.OK, "외부 배너 조회 성공")
     ;
 
     private final HttpStatus status;

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/BannerImage.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/BannerImage.java
@@ -5,8 +5,12 @@ import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.makers.operation.code.failure.BannerFailureCode;
+import org.sopt.makers.operation.code.failure.FailureCode;
+import org.sopt.makers.operation.exception.BannerException;
 
 import static lombok.AccessLevel.PROTECTED;
+import static org.sopt.makers.operation.code.failure.BannerFailureCode.NOT_SUPPORTED_PLATFORM_TYPE;
 
 @Getter
 @Embeddable
@@ -24,4 +28,11 @@ public class BannerImage {
         this.mobileImageUrl = updateMobileImageUrl;
     }
 
+    public String retrieveImageUrl(String platform) {
+      return switch (platform) {
+        case "pc" -> pcImageUrl;
+        case "mobile" -> mobileImageUrl;
+        default -> throw new BannerException(NOT_SUPPORTED_PLATFORM_TYPE);
+      };
+    }
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/repository/BannerRepository.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/repository/BannerRepository.java
@@ -1,10 +1,14 @@
 package org.sopt.makers.operation.banner.repository;
 
+import java.util.List;
 import org.sopt.makers.operation.banner.domain.Banner;
 
+import org.sopt.makers.operation.banner.domain.PublishLocation;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 @Repository
 public interface BannerRepository extends JpaRepository<Banner, Long> {
+
+  List<Banner> findBannersByLocation(PublishLocation publishLocation);
 }


### PR DESCRIPTION
## Related Issue 🚀
- closed #290 

## Work Description ✏️
- 배너 삭제 기능과 외부 배너 조회 기능을 구현했습니다. 

[배너 삭제](https://www.notion.so/sopt-makers/d8a77121bc1d4b13b1c9fd9f159a768e?pvs=4)

[외부 배너 조회](https://www.notion.so/sopt-makers/0bdc33f5dd98486da2bf851cde640b6b?pvs=4)


## PR Point 📸

배너 이미지 조회는 Embedded된 객체 내부에서 switch 문을 통해 해당하는 플랫폼 이미지를 반환하도록 구현했습니다. 
