### PR TITLE
[FEAT/#289] 배너 이미지 pre-sigend url 조회 및 배너 생성 API 구현

### DIFF
--- a/operation-api/src/main/java/org/sopt/makers/operation/common/handler/ErrorHandler.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/handler/ErrorHandler.java
@@ -98,6 +98,12 @@ public class ErrorHandler {
         return ApiResponseUtil.failure(ex.getFailureCode());
     }
 
+    @ExceptionHandler(BannerException.class)
+    public ResponseEntity<BaseResponse<?>> bannerException(BannerException ex) {
+        log.error(ex.getMessage());
+        return ApiResponseUtil.failure(ex.getFailureCode());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse<?>> validationException(MethodArgumentNotValidException ex) {
         List<String> errorMessages = ex.getBindingResult().getAllErrors().stream()

--- a/operation-api/src/main/java/org/sopt/makers/operation/common/handler/ErrorHandler.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/handler/ErrorHandler.java
@@ -104,6 +104,12 @@ public class ErrorHandler {
         return ApiResponseUtil.failure(ex.getFailureCode());
     }
 
+    @ExceptionHandler(ExternalException.class)
+    public ResponseEntity<BaseResponse<?>> externalException(ExternalException ex) {
+        log.error(ex.getMessage());
+        return ApiResponseUtil.failure(ex.getFailureCode());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse<?>> validationException(MethodArgumentNotValidException ex) {
         List<String> errorMessages = ex.getBindingResult().getAllErrors().stream()

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
@@ -31,4 +31,23 @@ public interface BannerApi {
     )
     ResponseEntity<BaseResponse<?>> getBannerDetail(Long bannerId);
 
+    @Operation(
+            summary = "배너 이미지 PreSignedUrl 조회 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "PreSignedUrl 조회 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청"
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 내부 오류"
+                    )
+            }
+    )
+    ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String bannerName, String imageTyp, String imageExtension);
+
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
@@ -49,7 +49,7 @@ public interface BannerApi {
                     )
             }
     )
-    ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String contentName, String imageType, String imageExtension, String contentType);
+    ResponseEntity<BaseResponse<?>> getIssuedPreSignedUrlForPutImage(String contentName, String imageType, String imageExtension, String contentType);
 
     @Operation(
             summary = "배너 생성 API",

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
@@ -48,6 +48,6 @@ public interface BannerApi {
                     )
             }
     )
-    ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String bannerName, String imageTyp, String imageExtension);
+    ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String bannerName, String imageType, String imageExtension);
 
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
@@ -48,6 +48,6 @@ public interface BannerApi {
                     )
             }
     )
-    ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String bannerName, String imageType, String imageExtension);
+    ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String contentName, String imageType, String imageExtension, String contentType);
 
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import org.sopt.makers.operation.dto.BaseResponse;
 
+import org.sopt.makers.operation.web.banner.dto.request.*;
 import org.springframework.http.ResponseEntity;
 
 public interface BannerApi {
@@ -49,5 +50,24 @@ public interface BannerApi {
             }
     )
     ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String contentName, String imageType, String imageExtension, String contentType);
+
+    @Operation(
+            summary = "배너 생성 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "배너 생성 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청"
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 내부 오류"
+                    )
+            }
+    )
+    ResponseEntity<BaseResponse<?>> createBanner(BannerRequest.BannerCreate request);
 
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_CREATE_BANNER;
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_DETAIL;
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL;
 
@@ -44,6 +45,7 @@ public class BannerApiController implements BannerApi {
 
     @Override
     public ResponseEntity<BaseResponse<?>> createBanner(@RequestBody BannerRequest.BannerCreate request) {
-        return null;
+        val response = bannerService.createBanner(request);
+        return ApiResponseUtil.success(SUCCESS_CREATE_BANNER, response);
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -30,7 +30,7 @@ public class BannerApiController implements BannerApi {
     }
 
     @Override
-    public ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String bannerName, String imageTyp,
+    public ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String bannerName, String imageType,
                                                                     String imageExtension) {
         return null;
     }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -7,12 +7,10 @@ import org.sopt.makers.operation.dto.BaseResponse;
 import org.sopt.makers.operation.util.ApiResponseUtil;
 import org.sopt.makers.operation.web.banner.service.BannerService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_DETAIL;
+import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL;
 
 @RestController
 @RequestMapping("/api/v1/banners")
@@ -30,8 +28,10 @@ public class BannerApiController implements BannerApi {
     }
 
     @Override
-    public ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String contentName, String imageType,
-                                                                    String imageExtension, String contentType) {
-        return null;
+    @GetMapping("/img/pre-signed")
+    public ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(@RequestParam("content-name") String contentName, @RequestParam("image-type") String imageType,
+                                                                    @RequestParam("image-extension") String imageExtension, @RequestParam("content-type") String contentType) {
+        val response = bannerService.getPutPreSignedUrlForBanner(contentName, imageType, imageExtension, contentType);
+        return ApiResponseUtil.success(SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL, response);
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -30,8 +30,8 @@ public class BannerApiController implements BannerApi {
     }
 
     @Override
-    public ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String bannerName, String imageType,
-                                                                    String imageExtension) {
+    public ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String contentName, String imageType,
+                                                                    String imageExtension, String contentType) {
         return null;
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -5,9 +5,16 @@ import lombok.val;
 
 import org.sopt.makers.operation.dto.BaseResponse;
 import org.sopt.makers.operation.util.ApiResponseUtil;
+import org.sopt.makers.operation.web.banner.dto.request.BannerRequest;
 import org.sopt.makers.operation.web.banner.service.BannerService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_DETAIL;
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL;
@@ -33,5 +40,10 @@ public class BannerApiController implements BannerApi {
                                                                     @RequestParam("image-extension") String imageExtension, @RequestParam("content-type") String contentType) {
         val response = bannerService.getPutPreSignedUrlForBanner(contentName, imageType, imageExtension, contentType);
         return ApiResponseUtil.success(SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL, response);
+    }
+
+    @Override
+    public ResponseEntity<BaseResponse<?>> createBanner(@RequestBody BannerRequest.BannerCreate request) {
+        return null;
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -32,9 +32,9 @@ public class BannerApiController implements BannerApi {
 
     @Override
     @GetMapping("/img/pre-signed")
-    public ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(@RequestParam("content-name") String contentName, @RequestParam("image-type") String imageType,
-                                                                    @RequestParam("image-extension") String imageExtension, @RequestParam("content-type") String contentType) {
-        val response = bannerService.getPutPreSignedUrlForBanner(contentName, imageType, imageExtension, contentType);
+    public ResponseEntity<BaseResponse<?>> getIssuedPreSignedUrlForPutImage(@RequestParam("content-name") String contentName, @RequestParam("image-type") String imageType,
+                                                                            @RequestParam("image-extension") String imageExtension, @RequestParam("content-type") String contentType) {
+        val response = bannerService.getIssuedPreSignedUrlForPutImage(contentName, imageType, imageExtension, contentType);
         return ApiResponseUtil.success(SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL, response);
     }
 

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -28,4 +28,10 @@ public class BannerApiController implements BannerApi {
         val response = bannerService.getBannerDetail(bannerId);
         return ApiResponseUtil.success(SUCCESS_GET_BANNER_DETAIL, response);
     }
+
+    @Override
+    public ResponseEntity<BaseResponse<?>> getPreSignedUrlForBanner(String bannerName, String imageTyp,
+                                                                    String imageExtension) {
+        return null;
+    }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -9,12 +9,7 @@ import org.sopt.makers.operation.web.banner.dto.request.BannerRequest;
 import org.sopt.makers.operation.web.banner.service.BannerService;
 import org.springframework.http.ResponseEntity;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_CREATE_BANNER;
 import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_DETAIL;
@@ -43,6 +38,7 @@ public class BannerApiController implements BannerApi {
         return ApiResponseUtil.success(SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL, response);
     }
 
+    @PostMapping
     @Override
     public ResponseEntity<BaseResponse<?>> createBanner(@RequestBody BannerRequest.BannerCreate request) {
         val response = bannerService.createBanner(request);

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/request/BannerRequest.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/request/BannerRequest.java
@@ -1,0 +1,22 @@
+package org.sopt.makers.operation.web.banner.dto.request;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.fasterxml.jackson.annotation.*;
+import java.time.*;
+import lombok.*;
+
+@RequiredArgsConstructor(access = PRIVATE)
+public class BannerRequest {
+
+    public record BannerCreate(
+            @JsonProperty("location") String bannerLocation,
+            @JsonProperty("content_type") String bannerType,
+            @JsonProperty("publisher") String publisher,
+            @JsonProperty("start_date") LocalDate startDate,
+            @JsonProperty("end_date") LocalDate endDate,
+            @JsonProperty("link") String link,
+            @JsonProperty("image_pc") String pcImage,
+            @JsonProperty("image_mobile") String mobileImage
+    ) {}
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/request/ImageExtension.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/request/ImageExtension.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ImageExtension {
-    JPG("jpg"), PNG("png");
+    PNG("png");
 
     private final String extension;
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/request/ImageExtension.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/request/ImageExtension.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.operation.web.banner.dto.request;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ImageExtension {
+    JPG("jpg"), PNG("png");
+
+    private final String extension;
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/request/ImageType.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/request/ImageType.java
@@ -4,7 +4,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ImageType {
-    PC("pc"), MOBILE("mo");
+    PC("pc", "/pc"), MOBILE("mo", "mobile");
 
     private final String type;
+    private final String location;
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/request/ImageType.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/request/ImageType.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.operation.web.banner.dto.request;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ImageType {
+    PC("pc"), MOBILE("mo");
+
+    private final String type;
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/response/BannerResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/response/BannerResponse.java
@@ -19,6 +19,7 @@ public final class BannerResponse {
             @JsonProperty("location") String bannerLocation,
             @JsonProperty("content_type") String bannerType,
             @JsonProperty("publisher") String publisher,
+            @JsonProperty("link") String link,
             @JsonProperty("start_date") LocalDate startDate,
             @JsonProperty("end_date") LocalDate endDate,
             @JsonProperty("image_url_pc") String pcImageUrl,
@@ -32,6 +33,7 @@ public final class BannerResponse {
                     .bannerLocation(banner.getLocation().getValue())
                     .bannerType(banner.getContentType().getValue())
                     .publisher(banner.getPublisher())
+                    .link(banner.getLink())
                     .startDate(banner.getPeriod().getStartDate())
                     .endDate(banner.getPeriod().getEndDate())
                     .pcImageUrl(banner.getImage().getPcImageUrl())

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/response/BannerResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/response/BannerResponse.java
@@ -39,4 +39,14 @@ public final class BannerResponse {
                     .build();
         }
     }
+
+    @Builder(access = PRIVATE)
+    public record ImagePreSignedUrl(
+            @JsonProperty("presigned-url") String preSignedUrl,
+            @JsonProperty("filename") String fileName
+    ) {
+        public static ImagePreSignedUrl of(String preSignedUrl, String filename) {
+            return new ImagePreSignedUrl(preSignedUrl, filename);
+        }
+    }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
@@ -7,5 +7,5 @@ public interface BannerService {
 
     BannerResponse.BannerDetail getBannerDetail(final long bannerId);
 
-    BannerResponse.ImagePreSignedUrl getPreSignedUrlForBanner(String bannerName, ImageType imageType, ImageExtension imageExtension);
+    BannerResponse.ImagePreSignedUrl getPreSignedUrlForBanner(String contentName, ImageType imageType, ImageExtension imageExtension, String contentType);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.operation.web.banner.service;
 
-import org.sopt.makers.operation.banner.domain.*;
 import org.sopt.makers.operation.web.banner.dto.request.*;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
 
@@ -8,7 +7,7 @@ public interface BannerService {
 
     BannerResponse.BannerDetail getBannerDetail(final long bannerId);
 
-    BannerResponse.ImagePreSignedUrl getPutPreSignedUrlForBanner(String contentName, String imageType, String imageExtension, String contentType);
+    BannerResponse.ImagePreSignedUrl getIssuedPreSignedUrlForPutImage(String contentName, String imageType, String imageExtension, String contentType);
 
     BannerResponse.BannerDetail createBanner(BannerRequest.BannerCreate request);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.operation.web.banner.service;
 
 import org.sopt.makers.operation.banner.domain.*;
+import org.sopt.makers.operation.web.banner.dto.request.*;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
 
 public interface BannerService {
@@ -8,4 +9,6 @@ public interface BannerService {
     BannerResponse.BannerDetail getBannerDetail(final long bannerId);
 
     BannerResponse.ImagePreSignedUrl getPutPreSignedUrlForBanner(String contentName, String imageType, String imageExtension, String contentType);
+
+    BannerResponse.BannerDetail createBanner(BannerRequest.BannerCreate request);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.operation.web.banner.service;
 
-import org.sopt.makers.operation.web.banner.dto.request.*;
+import org.sopt.makers.operation.banner.domain.*;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
 
 public interface BannerService {

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
@@ -1,8 +1,11 @@
 package org.sopt.makers.operation.web.banner.service;
 
+import org.sopt.makers.operation.web.banner.dto.request.*;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
 
 public interface BannerService {
 
     BannerResponse.BannerDetail getBannerDetail(final long bannerId);
+
+    BannerResponse.ImagePreSignedUrl getPreSignedUrlForBanner(String bannerName, ImageType imageType, ImageExtension imageExtension);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
@@ -7,5 +7,5 @@ public interface BannerService {
 
     BannerResponse.BannerDetail getBannerDetail(final long bannerId);
 
-    BannerResponse.ImagePreSignedUrl getPreSignedUrlForBanner(String contentName, ImageType imageType, ImageExtension imageExtension, String contentType);
+    BannerResponse.ImagePreSignedUrl getPutPreSignedUrlForBanner(String contentName, String imageType, String imageExtension, String contentType);
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -31,7 +31,7 @@ public class BannerServiceImpl implements BannerService {
 
     private Banner getBannerById(final long id) {
         return bannerRepository.findById(id)
-                .orElseThrow(() -> new BannerException(BannerFailureCode.NOT_FOUNT_BANNER));
+                .orElseThrow(() -> new BannerException(BannerFailureCode.NOT_FOUND_BANNER));
     }
 
     @Override

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -6,7 +6,9 @@ import org.sopt.makers.operation.banner.domain.Banner;
 import org.sopt.makers.operation.banner.repository.BannerRepository;
 import org.sopt.makers.operation.code.failure.BannerFailureCode;
 import org.sopt.makers.operation.exception.BannerException;
+import org.sopt.makers.operation.web.banner.dto.request.*;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
+import org.sopt.makers.operation.web.banner.dto.response.BannerResponse.*;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,5 +26,10 @@ public class BannerServiceImpl implements BannerService {
     private Banner getBannerById(final long id) {
         return bannerRepository.findById(id)
                 .orElseThrow(() -> new BannerException(BannerFailureCode.NOT_FOUNT_BANNER));
+    }
+
+    @Override
+    public BannerResponse.ImagePreSignedUrl getPreSignedUrlForBanner(String bannerName, ImageType imageType, ImageExtension imageExtension) {
+        return null;
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -14,9 +14,11 @@ import org.sopt.makers.operation.web.banner.dto.request.BannerRequest.*;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class BannerServiceImpl implements BannerService {
 
     private final BannerRepository bannerRepository;
@@ -53,6 +55,7 @@ public class BannerServiceImpl implements BannerService {
         return location+formattedDate + "_" + contentName + "(" + imageType + ")." + imageExtension;
     }
 
+    @Transactional
     @Override
     public BannerDetail createBanner(BannerCreate request) {
         val period = getPublishPeriod(request.startDate(), request.endDate());

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -37,12 +37,12 @@ public class BannerServiceImpl implements BannerService {
     }
 
     @Override
-    public BannerResponse.ImagePreSignedUrl getPutPreSignedUrlForBanner(String contentName, String imageType, String imageExtension, String contentType) {
+    public BannerResponse.ImagePreSignedUrl getIssuedPreSignedUrlForPutImage(String contentName, String imageType, String imageExtension, String contentType) {
         val type = ImageType.getByValue(imageType);
         val extension = ImageExtension.getByValue(imageExtension);
         val location = ContentType.getByValue(contentType).getLocation();
         val fileName = getBannerImageName(location, contentName, type.getValue(), extension.getValue());
-        val putPreSignedUrl = s3Service.createPutPreSignedUrl(valueConfig.getBannerBucket(), fileName);
+        val putPreSignedUrl = s3Service.createPreSignedUrlForPutObject(valueConfig.getBannerBucket(), fileName);
 
         return BannerResponse.ImagePreSignedUrl.of(putPreSignedUrl, fileName);
     }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -2,13 +2,11 @@ package org.sopt.makers.operation.web.banner.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.sopt.makers.operation.banner.domain.Banner;
+import org.sopt.makers.operation.banner.domain.*;
 import org.sopt.makers.operation.banner.repository.BannerRepository;
 import org.sopt.makers.operation.code.failure.BannerFailureCode;
 import org.sopt.makers.operation.exception.BannerException;
-import org.sopt.makers.operation.web.banner.dto.request.*;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
-import org.sopt.makers.operation.web.banner.dto.response.BannerResponse.*;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -27,7 +27,7 @@ public class BannerServiceImpl implements BannerService {
     }
 
     @Override
-    public BannerResponse.ImagePreSignedUrl getPreSignedUrlForBanner(String bannerName, ImageType imageType, ImageExtension imageExtension) {
+    public BannerResponse.ImagePreSignedUrl getPreSignedUrlForBanner(String contentName, ImageType imageType, ImageExtension imageExtension, String contentType) {
         return null;
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -27,7 +27,11 @@ public class BannerServiceImpl implements BannerService {
     }
 
     @Override
-    public BannerResponse.ImagePreSignedUrl getPreSignedUrlForBanner(String contentName, ImageType imageType, ImageExtension imageExtension, String contentType) {
+    public BannerResponse.ImagePreSignedUrl getPutPreSignedUrlForBanner(String contentName, String imageType, String imageExtension, String contentType) {
+        return null;
+    }
+
+    private String getBannerImageName(String contentName, String imageType, String imageExtension, String contentType) {
         return null;
     }
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -1,10 +1,17 @@
 package org.sopt.makers.operation.web.banner.service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.sopt.makers.operation.banner.domain.*;
+import org.sopt.makers.operation.banner.domain.ContentType;
+import org.sopt.makers.operation.banner.domain.ImageExtension;
+import org.sopt.makers.operation.banner.domain.ImageType;
+import org.sopt.makers.operation.banner.domain.Banner;
 import org.sopt.makers.operation.banner.repository.BannerRepository;
+import org.sopt.makers.operation.client.s3.S3Service;
 import org.sopt.makers.operation.code.failure.BannerFailureCode;
+import org.sopt.makers.operation.config.ValueConfig;
 import org.sopt.makers.operation.exception.BannerException;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
 import org.springframework.stereotype.Service;
@@ -14,6 +21,8 @@ import org.springframework.stereotype.Service;
 public class BannerServiceImpl implements BannerService {
 
     private final BannerRepository bannerRepository;
+    private final S3Service s3Service;
+    private final ValueConfig valueConfig;
 
     @Override
     public BannerResponse.BannerDetail getBannerDetail(final long bannerId) {
@@ -28,10 +37,20 @@ public class BannerServiceImpl implements BannerService {
 
     @Override
     public BannerResponse.ImagePreSignedUrl getPutPreSignedUrlForBanner(String contentName, String imageType, String imageExtension, String contentType) {
-        return null;
+        val type = ImageType.getByValue(imageType);
+        val extension = ImageExtension.getByValue(imageExtension);
+        val location = ContentType.getByValue(contentType).getLocation();
+        val fileName = getBannerImageName(location, contentName, type.getValue(), extension.getValue());
+        val putPreSignedUrl = s3Service.createPutPreSignedUrl(valueConfig.getBannerBucket(), fileName);
+
+        return BannerResponse.ImagePreSignedUrl.of(putPreSignedUrl, fileName);
     }
 
-    private String getBannerImageName(String contentName, String imageType, String imageExtension, String contentType) {
-        return null;
+    private String getBannerImageName(String location, String contentName, String imageType, String imageExtension) {
+        val today = LocalDate.now();
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        val formattedDate = today.format(formatter);
+
+        return location+formattedDate + "_" + contentName + "(" + imageType + ")." + imageExtension;
     }
 }

--- a/operation-api/src/main/resources/application-dev.yml
+++ b/operation-api/src/main/resources/application-dev.yml
@@ -84,7 +84,9 @@ cloud:
       secretKey: ${AWS_CREDENTIALS_ACCESS_KEY}
     eventBridge:
       roleArn: ${AWS_CREDENTIALS_EVENTBRIDGE_ROLE_ARN}
-    region: ${AWS_S3_REGION}
+    s3:
+      banner-bucket: ${BUCKET_FOR_BANNER}
+    region: ${AWS_REGION}
 
 management:
   endpoints:

--- a/operation-api/src/main/resources/application-dev.yml
+++ b/operation-api/src/main/resources/application-dev.yml
@@ -81,7 +81,7 @@ cloud:
   aws:
     credentials:
       accessKey: ${AWS_CREDENTIALS_ACCESS_KEY}
-      secretKey: ${AWS_CREDENTIALS_ACCESS_KEY}
+      secretKey: ${AWS_CREDENTIALS_SECRET_KEY}
     eventBridge:
       roleArn: ${AWS_CREDENTIALS_EVENTBRIDGE_ROLE_ARN}
     s3:

--- a/operation-api/src/main/resources/application-dev.yml
+++ b/operation-api/src/main/resources/application-dev.yml
@@ -84,6 +84,7 @@ cloud:
       secretKey: ${AWS_CREDENTIALS_ACCESS_KEY}
     eventBridge:
       roleArn: ${AWS_CREDENTIALS_EVENTBRIDGE_ROLE_ARN}
+    region: ${AWS_S3_REGION}
 
 management:
   endpoints:

--- a/operation-api/src/main/resources/application-dev.yml
+++ b/operation-api/src/main/resources/application-dev.yml
@@ -85,7 +85,8 @@ cloud:
     eventBridge:
       roleArn: ${AWS_CREDENTIALS_EVENTBRIDGE_ROLE_ARN}
     s3:
-      banner-bucket: ${BUCKET_FOR_BANNER}
+      banner:
+        name: ${BUCKET_FOR_BANNER}
     region: ${AWS_REGION}
 
 management:

--- a/operation-api/src/main/resources/application-test.yml
+++ b/operation-api/src/main/resources/application-test.yml
@@ -71,6 +71,9 @@ cloud:
       secretKey: test
     eventBridge:
       roleArn: test
+    s3:
+      banner:
+        name: banner
     region: test
 
 logging:

--- a/operation-api/src/main/resources/application-test.yml
+++ b/operation-api/src/main/resources/application-test.yml
@@ -71,6 +71,7 @@ cloud:
       secretKey: test
     eventBridge:
       roleArn: test
+    region: test
 
 logging:
   level:

--- a/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
@@ -47,7 +47,7 @@ class BannerApiControllerTest {
     @BeforeEach
     void setMockBanner() {
         BannerResponse.BannerDetail mockBannerDetail = new BannerResponse.BannerDetail(
-                MOCK_BANNER_ID, "in_progress", "pg_community", "product", "publisher",
+                MOCK_BANNER_ID, "in_progress", "pg_community", "product", "publisher", "link",
                 LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), "image-url-pc", "image-url-mobile"
         );
 
@@ -76,6 +76,7 @@ class BannerApiControllerTest {
                 .andExpect(jsonPath("$.data.location").value(givenBannerDetail.bannerLocation()))
                 .andExpect(jsonPath("$.data.content_type").value(givenBannerDetail.bannerType()))
                 .andExpect(jsonPath("$.data.publisher").value(givenBannerDetail.publisher()))
+                .andExpect(jsonPath("$.data.link").value(givenBannerDetail.link()))
                 .andExpect(jsonPath("$.data.start_date").value(givenBannerDetail.startDate().toString()))
                 .andExpect(jsonPath("$.data.end_date").value(givenBannerDetail.endDate().toString()))
                 .andExpect(jsonPath("$.data.image_url_pc").value(givenBannerDetail.pcImageUrl()))

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
@@ -17,6 +17,7 @@ public enum BannerFailureCode implements FailureCode {
     NOT_FOUND_LOCATION(NOT_FOUND, "존재하지 않는 게시 위치입니다."),
     NOT_FOUND_CONTENT_TYPE(NOT_FOUND, "존재하지 않는 게시 유형입니다."),
     NOT_FOUNT_BANNER(NOT_FOUND, "존재하지 않는 배너입니다."),
+    NOT_FOUND_BANNER_IMAGE(NOT_FOUND, "존재하지 않는 배너 이미지입니다.")
     ;
 
     private final HttpStatus status;

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
@@ -4,11 +4,13 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RequiredArgsConstructor
 @Getter
 public enum BannerFailureCode implements FailureCode {
+    INVALID_IMAGE_TYPE(BAD_REQUEST, "지원하지 않는 배너 이미지 형식입니다."),
     NOT_FOUND_STATUS(NOT_FOUND, "존재하지 않는 게시 상태입니다."),
     NOT_FOUND_LOCATION(NOT_FOUND, "존재하지 않는 게시 위치입니다."),
     NOT_FOUND_CONTENT_TYPE(NOT_FOUND, "존재하지 않는 게시 유형입니다."),

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
@@ -10,6 +10,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @RequiredArgsConstructor
 @Getter
 public enum BannerFailureCode implements FailureCode {
+    INVALID_BANNER_PERIOD(BAD_REQUEST, "배너 게시 기간이 올바르지 않습니다."),
     INVALID_IMAGE_EXTENSION(BAD_REQUEST, "지원하지 않는 배너 이미지 형식입니다."),
     INVALID_IMAGE_TYPE(BAD_REQUEST, "지원하지 않는 이미지 타입입니다."),
     NOT_FOUND_STATUS(NOT_FOUND, "존재하지 않는 게시 상태입니다."),

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
@@ -16,7 +16,7 @@ public enum BannerFailureCode implements FailureCode {
     NOT_FOUND_STATUS(NOT_FOUND, "존재하지 않는 게시 상태입니다."),
     NOT_FOUND_LOCATION(NOT_FOUND, "존재하지 않는 게시 위치입니다."),
     NOT_FOUND_CONTENT_TYPE(NOT_FOUND, "존재하지 않는 게시 유형입니다."),
-    NOT_FOUNT_BANNER(NOT_FOUND, "존재하지 않는 배너입니다."),
+    NOT_FOUND_BANNER(NOT_FOUND, "존재하지 않는 배너입니다."),
     NOT_FOUND_BANNER_IMAGE(NOT_FOUND, "존재하지 않는 배너 이미지입니다.")
     ;
 

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
@@ -10,7 +10,8 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @RequiredArgsConstructor
 @Getter
 public enum BannerFailureCode implements FailureCode {
-    INVALID_IMAGE_TYPE(BAD_REQUEST, "지원하지 않는 배너 이미지 형식입니다."),
+    INVALID_IMAGE_EXTENSION(BAD_REQUEST, "지원하지 않는 배너 이미지 형식입니다."),
+    INVALID_IMAGE_TYPE(BAD_REQUEST, "지원하지 않는 이미지 타입입니다."),
     NOT_FOUND_STATUS(NOT_FOUND, "존재하지 않는 게시 상태입니다."),
     NOT_FOUND_LOCATION(NOT_FOUND, "존재하지 않는 게시 위치입니다."),
     NOT_FOUND_CONTENT_TYPE(NOT_FOUND, "존재하지 않는 게시 유형입니다."),

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/ExternalFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/ExternalFailureCode.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.operation.code.failure;
+
+import static org.springframework.http.HttpStatus.*;
+
+import lombok.*;
+import org.springframework.http.*;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExternalFailureCode implements FailureCode {
+    FAIL_FOUND_S3_RESOURCE(NOT_FOUND, "S3에서 객체를 찾지 못했습니다");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/ExternalFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/ExternalFailureCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.*;
 @RequiredArgsConstructor
 @Getter
 public enum ExternalFailureCode implements FailureCode {
-    FAIL_FOUND_S3_RESOURCE(NOT_FOUND, "S3에서 객체를 찾지 못했습니다");
+    NOT_FOUND_S3_RESOURCE(NOT_FOUND, "S3에서 객체를 찾지 못했습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
@@ -11,6 +11,7 @@ import static lombok.AccessLevel.PRIVATE;
 @RequiredArgsConstructor(access = PRIVATE)
 public enum BannerSuccessCode implements SuccessCode {
     SUCCESS_GET_BANNER_DETAIL(HttpStatus.OK, "배너 상세 정보 조회 성공"),
+    SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL(HttpStatus.OK, "이미지 업로드 pre signed url 조회에 성공했습니다")
     ;
 
     private final HttpStatus status;

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
@@ -11,7 +11,8 @@ import static lombok.AccessLevel.PRIVATE;
 @RequiredArgsConstructor(access = PRIVATE)
 public enum BannerSuccessCode implements SuccessCode {
     SUCCESS_GET_BANNER_DETAIL(HttpStatus.OK, "배너 상세 정보 조회 성공"),
-    SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL(HttpStatus.OK, "이미지 업로드 pre signed url 조회에 성공했습니다")
+    SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL(HttpStatus.OK, "이미지 업로드 pre signed url 조회에 성공했습니다"),
+    SUCCESS_CREATE_BANNER(HttpStatus.CREATED, "배너 생성에 성공했습니다")
     ;
 
     private final HttpStatus status;

--- a/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
@@ -40,6 +40,8 @@ public class ValueConfig {
     private String region;
     @Value("${cloud.aws.eventBridge.roleArn}")
     private String eventBridgeRoleArn;
+    @Value("${cloud.aws.s3.banner-bucket}")
+    private String bannerBucket;
     @Value("${oauth.apple.key.id}")
     private String appleKeyId;
     @Value("${oauth.apple.key.path}")

--- a/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
@@ -40,7 +40,7 @@ public class ValueConfig {
     private String region;
     @Value("${cloud.aws.eventBridge.roleArn}")
     private String eventBridgeRoleArn;
-    @Value("${cloud.aws.s3.banner-bucket}")
+    @Value("${cloud.aws.s3.banner.name}")
     private String bannerBucket;
     @Value("${oauth.apple.key.id}")
     private String appleKeyId;

--- a/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/config/ValueConfig.java
@@ -36,6 +36,8 @@ public class ValueConfig {
     private String accessKey;
     @Value("${cloud.aws.credentials.secretKey}")
     private String secretKey;
+    @Value("${cloud.aws.region}")
+    private String region;
     @Value("${cloud.aws.eventBridge.roleArn}")
     private String eventBridgeRoleArn;
     @Value("${oauth.apple.key.id}")

--- a/operation-common/src/main/java/org/sopt/makers/operation/exception/ExternalException.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/exception/ExternalException.java
@@ -1,0 +1,15 @@
+package org.sopt.makers.operation.exception;
+
+import lombok.*;
+import org.sopt.makers.operation.code.failure.*;
+
+@Getter
+public class ExternalException extends RuntimeException {
+    private final FailureCode failureCode;
+
+    public ExternalException(FailureCode failureCode) {
+        super("[ExternalException] : " + failureCode.getMessage());
+        this.failureCode = failureCode;
+    }
+
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/Banner.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/Banner.java
@@ -61,8 +61,9 @@ public class Banner extends BaseEntity {
     private BannerImage image;
 
     @Builder
-    private Banner(PublishLocation location, ContentType contentType, String publisher, PublishPeriod period, BannerImage image) {
+    private Banner(PublishLocation location, String link, ContentType contentType, String publisher, PublishPeriod period, BannerImage image) {
         this.location = location;
+        this.link = link;
         this.contentType = contentType;
         this.publisher = publisher;
         this.period = period;

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/Banner.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/Banner.java
@@ -44,6 +44,8 @@ public class Banner extends BaseEntity {
     @Column(nullable = false)
     private String publisher;
 
+    private String link;
+
     @Embedded
     @AttributeOverrides({
             @AttributeOverride(name = "startDate", column = @Column(name = "start_date", nullable = false)),

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/BannerImage.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/BannerImage.java
@@ -9,7 +9,6 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Embeddable
 @NoArgsConstructor(access = PROTECTED)
-@AllArgsConstructor
 public class BannerImage {
     private String pcImageUrl;
     private String mobileImageUrl;
@@ -27,5 +26,4 @@ public class BannerImage {
         this.pcImageUrl = pcImageUrl;
         this.mobileImageUrl = mobileImageUrl;
     }
-
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/BannerImage.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/BannerImage.java
@@ -2,9 +2,7 @@ package org.sopt.makers.operation.banner.domain;
 
 import jakarta.persistence.Embeddable;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -22,6 +20,12 @@ public class BannerImage {
 
     public void updateMobileImage(String updateMobileImageUrl) {
         this.mobileImageUrl = updateMobileImageUrl;
+    }
+
+    @Builder
+    private BannerImage(String pcImageUrl, String mobileImageUrl) {
+        this.pcImageUrl = pcImageUrl;
+        this.mobileImageUrl = mobileImageUrl;
     }
 
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ContentType.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ContentType.java
@@ -13,14 +13,15 @@ import static lombok.AccessLevel.PRIVATE;
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)
 public enum ContentType {
-    PRODUCT("product"),
-    BIRTHDAY("birthday"),
-    SPONSOR("sponsor"),
-    EVENT("event"),
-    ETC("etc"),
+    PRODUCT("product", "/product"),
+    BIRTHDAY("birthday", "/birthday"),
+    SPONSOR("sponsor", "/sponsor"),
+    EVENT("event", "event"),
+    ETC("etc", "/etc"),
     ;
 
     private final String value;
+    private final String location;
 
     public static PublishLocation getByValue(String value) {
         return Arrays.stream(PublishLocation.values())

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ContentType.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ContentType.java
@@ -23,8 +23,8 @@ public enum ContentType {
     private final String value;
     private final String location;
 
-    public static PublishLocation getByValue(String value) {
-        return Arrays.stream(PublishLocation.values())
+    public static ContentType getByValue(String value) {
+        return Arrays.stream(ContentType.values())
                 .filter(location -> location.getValue().equals(value))
                 .findAny().orElseThrow(() -> new BannerException(BannerFailureCode.NOT_FOUND_CONTENT_TYPE));
     }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ContentType.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ContentType.java
@@ -13,11 +13,11 @@ import static lombok.AccessLevel.PRIVATE;
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)
 public enum ContentType {
-    PRODUCT("product", "/product"),
-    BIRTHDAY("birthday", "/birthday"),
-    SPONSOR("sponsor", "/sponsor"),
-    EVENT("event", "event"),
-    ETC("etc", "/etc"),
+    PRODUCT("product", "product/"),
+    BIRTHDAY("birthday", "birthday/"),
+    SPONSOR("sponsor", "sponsor/"),
+    EVENT("event", "event/"),
+    ETC("etc", "etc/"),
     ;
 
     private final String value;

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageExtension.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageExtension.java
@@ -1,4 +1,4 @@
-package org.sopt.makers.operation.web.banner.dto.request;
+package org.sopt.makers.operation.banner.domain;
 
 import lombok.RequiredArgsConstructor;
 

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageExtension.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageExtension.java
@@ -1,10 +1,21 @@
 package org.sopt.makers.operation.banner.domain;
 
+import java.util.Arrays;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.sopt.makers.operation.code.failure.BannerFailureCode;
+import org.sopt.makers.operation.exception.BannerException;
 
 @RequiredArgsConstructor
+@Getter
 public enum ImageExtension {
     PNG("png");
 
-    private final String extension;
+    private final String value;
+
+    public static ImageExtension getByValue(String value) {
+        return Arrays.stream(ImageExtension.values())
+                .filter(location -> location.getValue().equals(value))
+                .findAny().orElseThrow(() -> new BannerException(BannerFailureCode.INVALID_IMAGE_TYPE));
+    }
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageExtension.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageExtension.java
@@ -16,6 +16,6 @@ public enum ImageExtension {
     public static ImageExtension getByValue(String value) {
         return Arrays.stream(ImageExtension.values())
                 .filter(location -> location.getValue().equals(value))
-                .findAny().orElseThrow(() -> new BannerException(BannerFailureCode.INVALID_IMAGE_TYPE));
+                .findAny().orElseThrow(() -> new BannerException(BannerFailureCode.INVALID_IMAGE_EXTENSION));
     }
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageType.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageType.java
@@ -1,11 +1,21 @@
 package org.sopt.makers.operation.banner.domain;
 
-import lombok.RequiredArgsConstructor;
+import java.util.*;
+import lombok.*;
+import org.sopt.makers.operation.code.failure.*;
+import org.sopt.makers.operation.exception.*;
 
 @RequiredArgsConstructor
+@Getter
 public enum ImageType {
-    PC("pc", "/pc"), MOBILE("mo", "mobile");
+    PC("pc", "/pc"), MOBILE("mo", "/mobile");
 
-    private final String type;
+    private final String value;
     private final String location;
+
+    public static ImageType getByValue(String value) {
+        return Arrays.stream(ImageType.values())
+                .filter(location -> location.getValue().equals(value))
+                .findAny().orElseThrow(() -> new BannerException(BannerFailureCode.INVALID_IMAGE_TYPE));
+    }
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageType.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageType.java
@@ -1,4 +1,4 @@
-package org.sopt.makers.operation.web.banner.dto.request;
+package org.sopt.makers.operation.banner.domain;
 
 import lombok.RequiredArgsConstructor;
 

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageType.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/ImageType.java
@@ -8,10 +8,9 @@ import org.sopt.makers.operation.exception.*;
 @RequiredArgsConstructor
 @Getter
 public enum ImageType {
-    PC("pc", "/pc"), MOBILE("mo", "/mobile");
+    PC("pc"), MOBILE("mo");
 
     private final String value;
-    private final String location;
 
     public static ImageType getByValue(String value) {
         return Arrays.stream(ImageType.values())

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/PublishPeriod.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/PublishPeriod.java
@@ -2,13 +2,13 @@ package org.sopt.makers.operation.banner.domain;
 
 import jakarta.persistence.Embeddable;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
+import org.sopt.makers.operation.exception.*;
 
 import static lombok.AccessLevel.PROTECTED;
+import static org.sopt.makers.operation.code.failure.BannerFailureCode.INVALID_BANNER_PERIOD;
 
 @Getter
 @Embeddable
@@ -35,6 +35,19 @@ public class PublishPeriod {
             return PublishStatus.RESERVED;
         }
         return PublishStatus.IN_PROGRESS;
+    }
+
+    @Builder
+    private PublishPeriod(LocalDate startDate, LocalDate endDate) {
+        validatePublishPeriod(startDate, endDate);
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    private void validatePublishPeriod(LocalDate startDate, LocalDate endDate) {
+        if (endDate.isBefore(startDate)) {
+            throw new BannerException(INVALID_BANNER_PERIOD);
+        }
     }
 
 }

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/PublishPeriod.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/PublishPeriod.java
@@ -13,7 +13,6 @@ import static org.sopt.makers.operation.code.failure.BannerFailureCode.INVALID_B
 @Getter
 @Embeddable
 @NoArgsConstructor(access = PROTECTED)
-@AllArgsConstructor
 public class PublishPeriod {
     private LocalDate startDate;
     private LocalDate endDate;
@@ -49,5 +48,4 @@ public class PublishPeriod {
             throw new BannerException(INVALID_BANNER_PERIOD);
         }
     }
-
 }

--- a/operation-external/build.gradle
+++ b/operation-external/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation(platform("software.amazon.awssdk:bom:2.21.1"))
+    implementation 'software.amazon.awssdk:s3:2.21.0'
     implementation 'software.amazon.awssdk:eventbridge'
     implementation 'software.amazon.awssdk:scheduler'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3Manager.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3Manager.java
@@ -1,0 +1,51 @@
+package org.sopt.makers.operation.client.s3;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
+
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import org.sopt.makers.operation.config.ValueConfig;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Manager {
+    private static final String AWS_ACCESS_KEY_ID = "aws.accessKeyId";
+    private static final String AWS_SECRET_ACCESS_KEY = "aws.secretAccessKey";
+    private static final String AWS_REGION = "aws.region";
+    private final ValueConfig valueConfig;
+
+    @Bean
+    public SystemPropertyCredentialsProvider systemPropertyCredentialsProvider() {
+        System.setProperty(AWS_ACCESS_KEY_ID, valueConfig.getAccessKey());
+        System.setProperty(AWS_SECRET_ACCESS_KEY, valueConfig.getSecretKey());
+        System.setProperty(AWS_REGION, valueConfig.getRegion());
+        return SystemPropertyCredentialsProvider.create();
+    }
+
+    @Bean
+    public Region getRegion() {
+        return Region.of(valueConfig.getRegion());
+    }
+
+    @Bean
+    public S3Client getS3Client() {
+        return S3Client.builder()
+                .region(getRegion())
+                .credentialsProvider(systemPropertyCredentialsProvider())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner getS3Presigner() {
+        return S3Presigner.builder()
+                .region(getRegion())
+                .credentialsProvider(systemPropertyCredentialsProvider())
+                .build();
+    }
+}

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3Service.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3Service.java
@@ -1,0 +1,5 @@
+package org.sopt.makers.operation.client.s3;
+
+public interface S3Service {
+    String createPutPreSignedUrl(String fileName);
+}

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3Service.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3Service.java
@@ -1,5 +1,5 @@
 package org.sopt.makers.operation.client.s3;
 
 public interface S3Service {
-    String createPutPreSignedUrl(String fileName);
+    String createPutPreSignedUrl(String bucketName, String fileName);
 }

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3Service.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3Service.java
@@ -2,4 +2,6 @@ package org.sopt.makers.operation.client.s3;
 
 public interface S3Service {
     String createPutPreSignedUrl(String bucketName, String fileName);
+
+    String getUrl(String bucketName, String fileName);
 }

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3Service.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3Service.java
@@ -1,7 +1,7 @@
 package org.sopt.makers.operation.client.s3;
 
 public interface S3Service {
-    String createPutPreSignedUrl(String bucketName, String fileName);
+    String createPreSignedUrlForPutObject(String bucketName, String fileName);
 
     String getUrl(String bucketName, String fileName);
 }

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
@@ -2,14 +2,14 @@ package org.sopt.makers.operation.client.s3;
 
 import java.time.Duration;
 
+import lombok.val;
 import lombok.RequiredArgsConstructor;
 
-import org.sopt.makers.operation.config.*;
 import org.springframework.stereotype.Service;
 
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 @Service
 @RequiredArgsConstructor
@@ -19,11 +19,16 @@ public class S3ServiceImpl implements S3Service {
 
     @Override
     public String createPutPreSignedUrl(String bucketName, String fileName) {
-        PresignedPutObjectRequest preSignedRequest = s3Presigner
-                .presignPutObject(r -> r.signatureDuration(Duration.ofMinutes(SIGNATURE_DURATION))
-                        .putObjectRequest(por -> por.bucket(bucketName)
-                                .key(fileName)
-                                .acl(ObjectCannedACL.PUBLIC_READ)));
-        return preSignedRequest.url().toString();
+        val putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+        val preSignedUrlRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(SIGNATURE_DURATION))
+                .putObjectRequest(putObjectRequest)
+                .build();
+        val url = s3Presigner.presignPutObject(preSignedUrlRequest).url();
+
+        return url.toString();
     }
 }

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
@@ -1,14 +1,17 @@
 package org.sopt.makers.operation.client.s3;
 
+import static org.sopt.makers.operation.code.failure.BannerFailureCode.NOT_FOUND_BANNER_IMAGE;
+
 import java.time.Duration;
 
 import lombok.val;
 import lombok.RequiredArgsConstructor;
 
+import org.sopt.makers.operation.exception.*;
 import org.springframework.stereotype.Service;
 
 import software.amazon.awssdk.services.s3.*;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
@@ -36,6 +39,14 @@ public class S3ServiceImpl implements S3Service {
 
     @Override
     public String getUrl(String bucketName, String fileName) {
-        return s3Client.utilities().getUrl(b -> b.bucket(bucketName).key(fileName)).toExternalForm();
+        try {
+            return s3Client.utilities().getUrl(b -> b.bucket(bucketName).key(fileName)).toExternalForm();
+        } catch(NoSuchKeyException e) {
+            throw new BannerException(NOT_FOUND_BANNER_IMAGE);
+        }
+    }
+
+    public void deleteFile(String bucketName, String fileName){
+        s3Client.deleteObject(b -> b.bucket(bucketName).key(fileName));
     }
 }

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 
+import software.amazon.awssdk.services.s3.*;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -15,6 +16,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 @RequiredArgsConstructor
 public class S3ServiceImpl implements S3Service {
     private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
     private static final int SIGNATURE_DURATION = 20;
 
     @Override
@@ -30,5 +32,10 @@ public class S3ServiceImpl implements S3Service {
         val url = s3Presigner.presignPutObject(preSignedUrlRequest).url();
 
         return url.toString();
+    }
+
+    @Override
+    public String getUrl(String bucketName, String fileName) {
+        return s3Client.utilities().getUrl(b -> b.bucket(bucketName).key(fileName)).toExternalForm();
     }
 }

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
@@ -1,6 +1,6 @@
 package org.sopt.makers.operation.client.s3;
 
-import static org.sopt.makers.operation.code.failure.BannerFailureCode.NOT_FOUND_BANNER_IMAGE;
+import static org.sopt.makers.operation.code.failure.ExternalFailureCode.NOT_FOUND_S3_RESOURCE;
 
 import java.time.Duration;
 
@@ -42,7 +42,7 @@ public class S3ServiceImpl implements S3Service {
         try {
             return s3Client.utilities().getUrl(b -> b.bucket(bucketName).key(fileName)).toExternalForm();
         } catch(NoSuchKeyException e) {
-            throw new BannerException(NOT_FOUND_BANNER_IMAGE);
+            throw new ExternalException(NOT_FOUND_S3_RESOURCE);
         }
     }
 

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
@@ -1,0 +1,8 @@
+package org.sopt.makers.operation.client.s3;
+
+public class S3ServiceImpl implements S3Service {
+    @Override
+    public String createPutPreSignedUrl(String fileName) {
+        return null;
+    }
+}

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
@@ -23,7 +23,7 @@ public class S3ServiceImpl implements S3Service {
     private static final int SIGNATURE_DURATION = 20;
 
     @Override
-    public String createPutPreSignedUrl(String bucketName, String fileName) {
+    public String createPreSignedUrlForPutObject(String bucketName, String fileName) {
         val putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(fileName)

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/s3/S3ServiceImpl.java
@@ -1,8 +1,29 @@
 package org.sopt.makers.operation.client.s3;
 
+import java.time.Duration;
+
+import lombok.RequiredArgsConstructor;
+
+import org.sopt.makers.operation.config.*;
+import org.springframework.stereotype.Service;
+
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
 public class S3ServiceImpl implements S3Service {
+    private final S3Presigner s3Presigner;
+    private static final int SIGNATURE_DURATION = 20;
+
     @Override
-    public String createPutPreSignedUrl(String fileName) {
-        return null;
+    public String createPutPreSignedUrl(String bucketName, String fileName) {
+        PresignedPutObjectRequest preSignedRequest = s3Presigner
+                .presignPutObject(r -> r.signatureDuration(Duration.ofMinutes(SIGNATURE_DURATION))
+                        .putObjectRequest(por -> por.bucket(bucketName)
+                                .key(fileName)
+                                .acl(ObjectCannedACL.PUBLIC_READ)));
+        return preSignedRequest.url().toString();
     }
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #289

## Work Description ✏️
- AWS S3 bucket에 이미지 업로드 시 pre signed url을 사용할 수 있도록 했습니다
 - 다음과 같이 배너명과 배너를 생성한 일자, 이미지 유형 등이 이름에 포함됩니다
```
 {
    "success": true,
    "message": "이미지 업로드 pre signed url 조회에 성공했습니다",
    "data": {
        "presigned-url": "https://makers-banner.s3.ap-northeast-2.amazonaws.com/birthday/2024-12-23_happy%28mo%29.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20241222T171034Z&X-Amz-SignedHeaders=host&X-Amz-Expires=1200&X-Amz-Credential=AKIAVQPX6FSLFAUMBS55%2F20241222%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=b27ec52a28f7240a371ab22de0ae5d9a5162013d47d625d2362ebaaff5fd2892",
        "filename": "birthday/2024-12-23_happy(mo).png" // 클라이언트에서 다시 서버로 보내줄 값
    }
}
```

- pre signed url을 통한 이미지 업로드도 확인 완료했습니다
![image](https://github.com/user-attachments/assets/d5d4d5d9-5e89-4571-aa9c-42d7104259f7)

- 배너 생성 API도 확인 완료했습니다
![image](https://github.com/user-attachments/assets/f3d75d1f-c288-4a78-a82b-bde01e7d50ea)

- 배너 수정을 위해 S3에서 이미지를 삭제하는 로직을 미리 구현했습니다

*동규오빠 작업 머지 이후의 변경사항*
1. banner not found 예외 오탈자 수정 (NOT_FOUNT~ -> NOT_FOUND)
2. banner 엔티티에 link 필드 추가(nullable)
3. 캡쳐본에는 반영되지 않았지만, BannerDetail 조회 시에도 link 필드가 같이 내려가도록 했습니다
4. AWS key 관련해서 secret key 부분에 동일하게 access key 환경변수를 적용하고 있던 부분 수정했습니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 저희 어노테이션에 와일드카드 적용안하는 것 operation에서도 적용일까요? 일부 적용되어있는 클래스가 보여서 없애다가 일단 저도 중간부터는 수정안했습니다!
- S3 퍼블릭 액세스 관련해서 설정이 헷갈려서 시간이 좀 많이 걸렸네요 늦어서 죄송합니다