### PR TITLE
[REFACTOR/#295] 배포 방식 변경

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -6,14 +6,14 @@ on:
     branches: [ develop ]
 
 jobs:
-  build-and-push-and-deploy:
+  build-and-push:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Checkout
+      - name: ✅ Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: ⚙️ Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
@@ -27,16 +27,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
-        shell: bash
-
-      - name: Create Property
-        run: |
-          
-          mkdir -p ./operation-api/src/main/resources/static
-          echo "${{ secrets.APPLE_KEY }}" | base64 --decode > ./operation-api/src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
-
       - name: 🧱 Build Image and Push to ECR
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -47,36 +37,63 @@ jobs:
           docker tag $AWS_ECR_REPO:latest public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:latest
           docker push public.ecr.aws/$AWS_ACCOUNT_ID/$AWS_ECR_REPO:latest
 
-      - name: 📝 Copy Script File
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ✅ Checkout
+        uses: actions/checkout@v3
+
+      - name: 🔒 Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: 📝 Copy Files from S3
         env:
           REGION: ${{ secrets.AWS_REGION }}
+          APPLE_KEY_NAME: ${{ secrets.APPLE_KEY_NAME }}
           S3_BUCKET: ${{ secrets.AWS_BUCKET_NAME }}
         run: |
-          mkdir ./script
           aws s3 cp --region $REGION \
-            s3://$S3_BUCKET/dev/script/deploy.sh ./script/deploy.sh
+            s3://$S3_BUCKET/dev/script/deploy.sh ./deploy.sh
           aws s3 cp --region $REGION \
-            s3://$S3_BUCKET/dev/script/switch.sh ./script/switch.sh
+            s3://$S3_BUCKET/dev/script/switch.sh ./switch.sh
           aws s3 cp --region $REGION \
-            s3://$S3_BUCKET/dev/script/valid.sh ./script/valid.sh
-          
-          aws s3 cp --region $REGION \
-            s3://$S3_BUCKET/dev/dev.env application.env
+            s3://$S3_BUCKET/dev/script/valid.sh ./valid.sh
 
-      - name: Make zip file
-        run: zip -r ./$GITHUB_SHA.zip ./script ./appspec.yml ./application.env
-        shell: bash
+          aws s3 cp --region $REGION \
+            s3://$S3_BUCKET/dev/dev.env ./application.env
+          aws s3 cp --region $REGION \
+            s3://$S3_BUCKET/dev/static/$APPLE_KEY ./$APPLE_KEY_NAME
 
-      - name: Upload Property Zip to S3 and Create Code Deploy
-        env:
-          REGION: ${{ secrets.AWS_REGION }}
-          DEPLOY_APPLICATION: ${{ secrets.AWS_DEPLOY_APPLICATION }}
-          DEPLOY_GROUP: ${{ secrets.AWS_DEPLOY_GROUP_DEV }}
-          S3_BUCKET: ${{ secrets.AWS_BUCKET_NAME }}
-        run: |
-          aws s3 cp --region $REGION ./$GITHUB_SHA.zip s3://$S3_BUCKET/dev/deploy/$GITHUB_SHA.zip
-          
-          aws deploy create-deployment --application-name $DEPLOY_APPLICATION \
-          --deployment-config-name CodeDeployDefault.AllAtOnce \
-          --deployment-group-name $DEPLOY_GROUP \
-          --s3-location bucket=$S3_BUCKET,bundleType=zip,key=dev/deploy/$GITHUB_SHA.zip
+      - name: 🚀SSH command deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST_DEV }}
+          username: ubuntu
+          key: ${{ secrets.PEM_KEY_DEV }}
+          port: 22
+          script: |
+            mkdir -p /home/ubuntu/script/op
+            mkdir -p /home/ubuntu/property/op
+            mkdir -p /home/ubuntu/env/op
+            
+            echo $(cat deploy.sh) > /home/ubuntu/script/op/deploy.sh
+            echo $(cat switch.sh) > /home/ubuntu/script/op/switch.sh
+            echo $(cat valid.sh) > /home/ubuntu/script/op/valid.sh
+            echo $(cat application.env) > /home/ubuntu/env/op/application.env
+            echo $(cat ${{ secrets.APPLE_KEY_NAME }}) > /home/ubuntu/property/op/key/${{ secrets.APPLE_KEY_NAME }}
+            
+            sudo chmod +x /home/ubuntu/script/op/deploy.sh
+            sudo chmod +x /home/ubuntu/script/op/switch.sh
+            sudo chmod +x /home/ubuntu/script/op/valid.sh
+            sudo chmod +r /home/ubuntu/env/op/application.env
+            sudo chmod +r /home/ubuntu/property/op/key/${{ secrets.APPLE_KEY }}
+            
+            ./home/ubuntu/script/op/deploy.sh
+            ./home/ubuntu/script/op/switch.sh
+            ./home/ubuntu/script/op/valid.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,28 +23,6 @@ jobs:
         run: chmod +x ./gradlew
         shell: bash
 
-      - name: Create application.yml
-        run: |
-          pwd
-          cd ./operation-api/src/main/resources
-          touch ./application-dev.yml
-          echo "${{ secrets.APPLICATION_DEV }}" >> ./application-dev.yml
-          cat ./application-dev.yml
-
-      - name: Create application-test.yml
-        run: |
-          cd ./operation-domain/src/test
-          mkdir -p resources
-          touch ./resources/application-test.yml
-          echo "${{ secrets.APPLICATION_DOMAIN_TEST }}" >> ./application-test.yml
-          cat ./application-test.yml
-
-      - name: 'Get key from Github Secrets'
-        run: |
-          pwd
-          mkdir -p ./operation-api/src/main/resources/static
-          echo "${{ secrets.APPLE_KEY }}" | base64 --decode > ./operation-api/src/main/resources/static/${{ secrets.APPLE_KEY_NAME }}
-
-      - name: Build with Gradle
-        run: ./gradlew build
+      - name: 🧱 Build with Gradle
+        run: docker build -t app-ci .
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-jdk-slim as builder
 
+ARG PROFILE=test
+
 # mkdir /app-build && cd /app-build
 WORKDIR /app-build
 
@@ -7,7 +9,7 @@ WORKDIR /app-build
 COPY . /app-build
 
 # create .jar
-RUN ./gradlew build -x test
+RUN echo "Build with PROFILE=${PROFILE}" && ./gradlew build -Pprofile=${PROFILE} --no-daemon
 
 # Run-Time Image Setting
 FROM openjdk:17-jdk-slim as production

--- a/operation-api/build.gradle
+++ b/operation-api/build.gradle
@@ -19,6 +19,19 @@ tasks.named("bootJar") {
     })
 }
 
+def profile = project.findProperty("profile") ?: "test"
+println("Build Profile: $profile")
+
+tasks.register("processProfileYaml", Copy) {
+    from("src/main/resources/application-${profile}.yaml")
+    into("build/resources/main") // 빌드 시 사용할 리소스 경로
+    rename { "application.yaml" } // 모든 프로파일 파일을 application.yaml로 변경
+}
+
+// processResources 작업 후에 실행되도록 의존성 추가
+tasks.named("processResources") {
+    dependsOn("processProfileYaml")
+}
 dependencies {
     // module
     implementation project(path: ':operation-auth')

--- a/operation-domain/src/test/java/org/sopt/makers/operation/banner/BannerTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/banner/BannerTest.java
@@ -48,12 +48,12 @@ public class BannerTest {
     private static final String TEST_BANNER_PC_IMAGE_URL = "image-url-for-pc";
     private static final String TEST_BANNER_MOBILE_IMAGE_URL = "image-url-for-mobile";
 
-    private static final PublishPeriod TEST_PUBLISH_PERIOD = new PublishPeriod(
-            TEST_BANNER_START_DATE, TEST_BANNER_END_DATE
-    );
-    private static final BannerImage TEST_BANNER_IMAGE = new BannerImage(
-            TEST_BANNER_PC_IMAGE_URL, TEST_BANNER_MOBILE_IMAGE_URL
-    );
+    private static final PublishPeriod TEST_PUBLISH_PERIOD = PublishPeriod.builder()
+            .startDate(TEST_BANNER_START_DATE)
+            .endDate(TEST_BANNER_END_DATE).build();
+    private static final BannerImage TEST_BANNER_IMAGE = BannerImage.builder()
+            .pcImageUrl(TEST_BANNER_PC_IMAGE_URL)
+            .mobileImageUrl(TEST_BANNER_MOBILE_IMAGE_URL).build();
 
     private static final Banner TEST_BANNER = Banner.builder()
             .location(TEST_BANNER_LOCATION)

--- a/operation-domain/src/test/java/org/sopt/makers/operation/banner/PublishPeriodTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/banner/PublishPeriodTest.java
@@ -17,7 +17,9 @@ public class PublishPeriodTest {
 
     private static final LocalDate TEST_START_DATE = LocalDate.of(2024,1,1);
     private static final LocalDate TEST_END_DATE = LocalDate.of(2024,12,31);
-    private final PublishPeriod givenPeriod = new PublishPeriod(TEST_START_DATE, TEST_END_DATE);
+    private final PublishPeriod givenPeriod = PublishPeriod.builder()
+            .startDate(TEST_START_DATE)
+            .endDate(TEST_END_DATE).build();
 
     @ParameterizedTest(name = "({index}) date : {0} -> result : {1}")
     @MethodSource("argsForCalculateStatus")


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #295 

## Work Description ✏️
- CI 
  - docker 기반 Build 방식으로 변경했습니다.
  - `operation-api` 모듈의 `build.gradle` 내에 build profile parameter(`-Pprofile`)에 따라 yaml 파일을 선택할 수 있도록 했습니다.
  - test yaml의 경우, 변경 필요성이 존재하지 않기 때문에 제외 했습니다.
- CD
  - EC2 SSH 접속 및 배포 명령 방식으로 변경했습니다.

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->

### ※ CI Script Build 명령 시, `-x test`(테스트 제외) 제거
기존 CI의 경우, Local에서의 테스트 통과 후 PR을 생성하는 컨벤션에 의존한 채 Script 내에서는 테스트를 제외하고 Build 했습니다.
하지만 신뢰성 보장 후에 Merge 및 배포되는 것이 바람직하다고 판단하여 `-x test` 명령을 제거했습니다.

<br/>

### ※ SSH 접속 & Github Actions 로컬 환경 파일 복사
<작업>
- Code Deploy를 활용하여 Deployment 생성 & EC2 내 Code Deploy Agent 로 배포 실행되는 방식에서 Github Actions에서 SSH로 직접 접속하여 배포를 실행하도록 변경했습니다.
- EC2 내 저장 공간을 확보하기 위해 Java(Docker 기반 배포이기 때문에 불필요) & Ruby(Code Deploy Agent)를 제거했습니다.

<이유>
- 배포 과정에서 EC2 내에 실행되는 리소스 및 프로세스를 최소화
- 배포 과정 가시화 (인수인계 효율, 문서화 용이)
- AWS 서비스 의존성 절감

<우려점>
- Github Actions 내에서 사용하는 `appleboy`라이브러리 변경에 대한 의존성 우려