### PR TITLE
[FEAT/#297] 배너 목록 조회 기능 구현

### DIFF
--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApi.java
@@ -33,6 +33,25 @@ public interface BannerApi {
     ResponseEntity<BaseResponse<?>> getBannerDetail(Long bannerId);
 
     @Operation(
+            summary = "배너 목록 조회 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "배너 목록 조회 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청<br/><br/>1. 존재하지 않는 Parameter Key<br/>2. 존재하지 않는 Parameter Value"
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 내부 오류"
+                    )
+            }
+    )
+    ResponseEntity<BaseResponse<?>> getBanners(String status, String sort);
+
+    @Operation(
         summary = "배너 삭제 API",
         responses = {
             @ApiResponse(

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/api/BannerApiController.java
@@ -3,12 +3,11 @@ package org.sopt.makers.operation.web.banner.api;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 
-import org.sopt.makers.operation.code.success.web.BannerSuccessCode;
 import org.sopt.makers.operation.dto.BaseResponse;
 import org.sopt.makers.operation.util.ApiResponseUtil;
 import org.sopt.makers.operation.web.banner.dto.request.BannerRequest;
-import org.sopt.makers.operation.web.banner.dto.request.BannerRequest.BannerCreate;
 import org.sopt.makers.operation.web.banner.service.BannerService;
+import org.sopt.makers.operation.web.banner.service.BannerService.FilterCriteria;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,11 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_CREATE_BANNER;
-import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_DELETE_BANNER;
-import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_DETAIL;
-import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL;
-import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.SUCCESS_GET_EXTERNAL_BANNERS;
+import static org.sopt.makers.operation.code.success.web.BannerSuccessCode.*;
+import static org.sopt.makers.operation.web.banner.service.BannerService.*;
 
 import org.springframework.web.bind.annotation.*;
 
@@ -39,6 +35,19 @@ public class BannerApiController implements BannerApi {
   ) {
     val response = bannerService.getBannerDetail(bannerId);
     return ApiResponseUtil.success(SUCCESS_GET_BANNER_DETAIL, response);
+  }
+
+  @Override
+  @GetMapping
+  public ResponseEntity<BaseResponse<?>> getBanners(
+          @RequestParam(value = "filter", required = false, defaultValue = "all") String filterCriteriaParameter,
+          @RequestParam(value = "sort", required = false, defaultValue = "status") String sortCriteriaParameter
+  ) {
+    val progressStatus = FilterCriteria.fromParameter(filterCriteriaParameter);
+    val sortCriteria = SortCriteria.fromParameter(sortCriteriaParameter);
+
+    val response = bannerService.getBanners(progressStatus, sortCriteria);
+    return ApiResponseUtil.success(SUCCESS_GET_BANNER_LIST, response);
   }
 
   @Override

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/response/BannerResponse.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/dto/response/BannerResponse.java
@@ -15,6 +15,30 @@ import static lombok.AccessLevel.PRIVATE;
 public final class BannerResponse {
 
     @Builder(access = PRIVATE)
+    public record BannerSimple (
+            @JsonProperty("id") long bannerId,
+            @JsonProperty("status") String bannerStatus,
+            @JsonProperty("location") String bannerLocation,
+            @JsonProperty("content_type") String bannerType,
+            @JsonProperty("publisher") String publisher,
+            @JsonProperty("start_date") LocalDate startDate,
+            @JsonProperty("end_date") LocalDate endDate
+    ) {
+        public static BannerSimple fromEntity(Banner banner) {
+            return BannerSimple.builder()
+                    .bannerId(banner.getId())
+                    .bannerStatus(banner.getPeriod().getPublishStatus(LocalDate.now()).getValue())
+                    .bannerLocation(banner.getLocation().getValue())
+                    .bannerType(banner.getContentType().getValue())
+                    .publisher(banner.getPublisher())
+                    .startDate(banner.getPeriod().getStartDate())
+                    .endDate(banner.getPeriod().getEndDate())
+                    .build();
+        }
+    }
+
+
+    @Builder(access = PRIVATE)
     public record BannerDetail(
             @JsonProperty("id") long bannerId,
             @JsonProperty("status") String bannerStatus,

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
@@ -1,10 +1,12 @@
 package org.sopt.makers.operation.web.banner.service;
 
+import java.util.Arrays;
 import java.util.List;
 
+import org.sopt.makers.operation.code.failure.BannerFailureCode;
+import org.sopt.makers.operation.exception.BannerException;
 import org.sopt.makers.operation.web.banner.dto.request.*;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
-import org.sopt.makers.operation.web.banner.dto.response.BannerResponse.BannerDetail;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse.BannerImageUrl;
 
 public interface BannerService {
@@ -18,5 +20,47 @@ public interface BannerService {
     BannerResponse.ImagePreSignedUrl getIssuedPreSignedUrlForPutImage(String contentName, String imageType, String imageExtension, String contentType);
 
     BannerResponse.BannerDetail createBanner(BannerRequest.BannerCreate request);
+
+    List<BannerResponse.BannerSimple> getBanners(final FilterCriteria status, final SortCriteria sort);
+
+    enum FilterCriteria {
+        ALL("all"),
+        RESERVED("reserved"),
+        IN_PROGRESS("in_progress"),
+        DONE("done"),
+        ;
+        private final String parameter;
+
+        FilterCriteria(String parameter) {
+            this.parameter = parameter;
+        }
+
+        public String getParameter() {
+            return this.parameter;
+        }
+
+        public static FilterCriteria fromParameter(String parameter) {
+            return Arrays.stream(FilterCriteria.values())
+                    .filter(value -> value.parameter.equals(parameter))
+                    .findAny().orElseThrow(() -> new BannerException(BannerFailureCode.INVALID_BANNER_PROGRESS_STATUS_PARAMETER));
+        }
+
+    }
+    enum SortCriteria {
+        START_DATE("start_date"),
+        END_DATE("end_date"),
+        STATUS("status")
+        ;
+        private final String parameter;
+
+        SortCriteria(String parameter) {
+            this.parameter = parameter;
+        }
+        public static SortCriteria fromParameter(String parameter) {
+            return Arrays.stream(SortCriteria.values())
+                    .filter(value -> value.parameter.equals(parameter))
+                    .findAny().orElseThrow(() -> new BannerException(BannerFailureCode.INVALID_BANNER_SORT_CRITERIA_PARAMETER));
+        }
+    }
   
 }

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -110,10 +110,10 @@ public class BannerServiceImpl implements BannerService {
     }
 
     private List<Banner> getFilteredBanners(List<Banner> banners, FilterCriteria filter) {
-        val targetStatus = PublishStatus.getByValue(filter.getParameter());
-        if (targetStatus == null) {
+        if (FilterCriteria.ALL.equals(filter)) {
             return banners;
         }
+        val targetStatus = PublishStatus.getByValue(filter.getParameter());
         return banners.stream()
                 .filter(banner -> targetStatus.equals(banner.getPeriod().getPublishStatus(LocalDate.now())))
                 .toList();

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -1,8 +1,8 @@
 package org.sopt.makers.operation.web.banner.service;
 
+import java.time.Clock;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.makers.operation.banner.domain.Banner;
@@ -31,6 +31,7 @@ public class BannerServiceImpl implements BannerService {
     private final BannerRepository bannerRepository;
     private final S3Service s3Service;
     private final ValueConfig valueConfig;
+    private final Clock clock;
 
     @Override
     public BannerResponse.BannerDetail getBannerDetail(final long bannerId) {
@@ -52,7 +53,7 @@ public class BannerServiceImpl implements BannerService {
 
      List<String> list = bannerList.stream()
          .map( banner -> banner.getImage().retrieveImageUrl(imageType))
-         .collect(Collectors.toUnmodifiableList());
+         .toList();
 
     return BannerResponse.BannerImageUrl.fromEntity(list);
   }
@@ -74,7 +75,7 @@ public class BannerServiceImpl implements BannerService {
     }
 
     private String getBannerImageName(String location, String contentName, String imageType, String imageExtension) {
-        val today = LocalDate.now();
+        val today = LocalDate.now(clock);
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         val formattedDate = today.format(formatter);
 
@@ -115,7 +116,7 @@ public class BannerServiceImpl implements BannerService {
         }
         val targetStatus = PublishStatus.getByValue(filter.getParameter());
         return banners.stream()
-                .filter(banner -> targetStatus.equals(banner.getPeriod().getPublishStatus(LocalDate.now())))
+                .filter(banner -> targetStatus.equals(banner.getPeriod().getPublishStatus(LocalDate.now(clock))))
                 .toList();
     }
 

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerServiceImpl.java
@@ -1,5 +1,6 @@
 package org.sopt.makers.operation.web.banner.service;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -9,8 +10,6 @@ import org.sopt.makers.operation.banner.domain.PublishLocation;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import lombok.RequiredArgsConstructor;
-import lombok.val;
 import org.sopt.makers.operation.banner.domain.*;
 
 import org.sopt.makers.operation.banner.repository.BannerRepository;
@@ -98,6 +97,39 @@ public class BannerServiceImpl implements BannerService {
         val banner = saveBanner(newBanner);
 
         return BannerResponse.BannerDetail.fromEntity(banner);
+    }
+
+    @Override
+    public List<BannerSimple> getBanners(FilterCriteria filter, SortCriteria sort) {
+        val allBanners = bannerRepository.findAll();
+        val filteredBanners = getFilteredBanners(allBanners, filter);
+        val resultBanners = getSortedBanners(filteredBanners, sort);
+        return resultBanners.stream()
+                .map(BannerSimple::fromEntity)
+                .toList();
+    }
+
+    private List<Banner> getFilteredBanners(List<Banner> banners, FilterCriteria filter) {
+        val targetStatus = PublishStatus.getByValue(filter.getParameter());
+        if (targetStatus == null) {
+            return banners;
+        }
+        return banners.stream()
+                .filter(banner -> targetStatus.equals(banner.getPeriod().getPublishStatus(LocalDate.now())))
+                .toList();
+    }
+
+    private List<Banner> getSortedBanners(List<Banner> banners, SortCriteria criteria) {
+        return switch (criteria) {
+            case STATUS, START_DATE -> banners.stream().sorted(
+                    Comparator.comparing(Banner::getPeriod, (p1, p2) -> p2.getStartDate().compareTo(p1.getStartDate()))
+                            .thenComparing(Banner::getPeriod, Comparator.comparing(PublishPeriod::getEndDate))
+            ).toList();
+            case END_DATE -> banners.stream().sorted(
+                    Comparator.comparing(Banner::getPeriod, Comparator.comparing(PublishPeriod::getEndDate))
+                            .thenComparing(Banner::getPeriod, (p1, p2) -> p2.getStartDate().compareTo(p1.getStartDate()))
+            ).toList();
+        };
     }
 
     private PublishPeriod getPublishPeriod(LocalDate startDate, LocalDate endDate) {

--- a/operation-api/src/main/resources/data/insert-get-banners-data.sql
+++ b/operation-api/src/main/resources/data/insert-get-banners-data.sql
@@ -1,0 +1,57 @@
+CREATE TABLE if not exists banners (
+     id bigserial not null,
+     created_date timestamp(6),
+     last_modified_date timestamp(6),
+     content_type varchar(255) not null,
+     img_url_mobile varchar(255) not null,
+     img_url_pc varchar(255) not null,
+     link varchar(255),
+     location varchar(255) not null,
+     end_date date not null,
+     start_date date not null,
+     publisher varchar(255) not null,
+     primary key (id)
+);
+
+DELETE FROM banners;
+
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2031-06-10', '2031-06-17','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2031-06-01', '2031-06-30','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2031-01-01', '2031-06-30','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2030-01-01', '2030-12-31','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2030-01-01', '2030-06-30','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2030-01-01', '2030-12-31','user');
+
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2024-12-01', '2024-12-31','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2024-12-01', '2025-12-01','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2024-01-01', '2025-06-30','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2024-06-30', '2025-06-30','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2024-06-30', '2025-01-01','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2024-01-01', '2025-01-01','user');
+
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2011-06-10', '2011-06-17','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2011-06-01', '2011-06-30','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2011-01-01', '2011-06-30','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2010-01-01', '2011-12-31','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2010-01-01', '2010-06-30','user');
+INSERT INTO banners (content_type, img_url_mobile, img_url_pc, location, start_date, end_date, publisher)
+VALUES ('PRODUCT', '','','PLAYGROUND_COMMUNITY','2010-01-01', '2010-12-31','user');
+
+

--- a/operation-api/src/test/java/org/sopt/makers/operation/web/banner/service/BannerServiceTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/web/banner/service/BannerServiceTest.java
@@ -1,0 +1,59 @@
+package org.sopt.makers.operation.web.banner.service;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.sopt.makers.operation.banner.domain.PublishPeriod;
+import org.sopt.makers.operation.banner.domain.PublishStatus;
+import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sopt.makers.operation.web.banner.service.BannerService.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Sql(scripts = "classpath:data/insert-get-banners-data.sql")
+class BannerServiceTest {
+
+    @Autowired
+    private BannerService bannerService;
+
+
+    @ParameterizedTest
+    @MethodSource("argsForGetBanners")
+    void getBanners(
+            FilterCriteria givenFilter,
+            SortCriteria givenSort,
+            int expectedSize,
+            PublishStatus expectedStatus
+    ) {
+        List<BannerResponse.BannerSimple> banners = bannerService.getBanners(givenFilter, givenSort);
+
+        assertThat(banners)
+                .hasSize(expectedSize)
+                .extracting(info -> PublishPeriod.builder().startDate(info.startDate()).endDate(info.endDate()).build())
+                .allMatch(period -> {
+                    if (givenFilter.equals(FilterCriteria.ALL)) {
+                        return true;
+                    }
+                    return period.getPublishStatus(LocalDate.now()).equals(expectedStatus);
+                });
+    }
+    static Stream<Arguments> argsForGetBanners(){
+        return Stream.of(
+                Arguments.of(FilterCriteria.RESERVED, SortCriteria.START_DATE, 6, PublishStatus.RESERVED),
+                Arguments.of(FilterCriteria.ALL, SortCriteria.START_DATE, 18, null),
+                Arguments.of(FilterCriteria.IN_PROGRESS, SortCriteria.START_DATE, 6, PublishStatus.IN_PROGRESS),
+                Arguments.of(FilterCriteria.DONE, SortCriteria.START_DATE, 6, PublishStatus.DONE)
+        );
+    }
+
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/BannerFailureCode.java
@@ -19,8 +19,10 @@ public enum BannerFailureCode implements FailureCode {
     NOT_FOUNT_BANNER(NOT_FOUND, "존재하지 않는 배너입니다."),
     NOT_SUPPORTED_PLATFORM_TYPE(NOT_FOUND, "지원하지 않는 플랫폼 유형입니다."),
     NOT_FOUND_BANNER(NOT_FOUND, "존재하지 않는 배너입니다."),
-    NOT_FOUND_BANNER_IMAGE(NOT_FOUND, "존재하지 않는 배너 이미지입니다.")
+    NOT_FOUND_BANNER_IMAGE(NOT_FOUND, "존재하지 않는 배너 이미지입니다."),
 
+    INVALID_BANNER_PROGRESS_STATUS_PARAMETER(BAD_REQUEST, "올바르지 않은 배너 진행 상태 조건입니다."),
+    INVALID_BANNER_SORT_CRITERIA_PARAMETER(BAD_REQUEST, "올바르지 않은 배너 정렬 조건입니다."),
     ;
 
     private final HttpStatus status;

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/success/web/BannerSuccessCode.java
@@ -11,6 +11,7 @@ import static lombok.AccessLevel.PRIVATE;
 @RequiredArgsConstructor(access = PRIVATE)
 public enum BannerSuccessCode implements SuccessCode {
     SUCCESS_GET_BANNER_DETAIL(HttpStatus.OK, "배너 상세 정보 조회 성공"),
+    SUCCESS_GET_BANNER_LIST(HttpStatus.OK, "배너 목록 정보 조회 성공"),
     SUCCESS_DELETE_BANNER(HttpStatus. NO_CONTENT, "배너 삭제 성공"),
     SUCCESS_GET_EXTERNAL_BANNERS(HttpStatus.OK, "외부 배너 조회 성공"),
     SUCCESS_GET_BANNER_IMAGE_PRE_SIGNED_URL(HttpStatus.OK, "이미지 업로드 pre signed url 조회에 성공했습니다"),

--- a/operation-common/src/main/java/org/sopt/makers/operation/config/TimeConfig.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/config/TimeConfig.java
@@ -1,0 +1,16 @@
+package org.sopt.makers.operation.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+
+}

--- a/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/PublishStatus.java
+++ b/operation-domain/src/main/java/org/sopt/makers/operation/banner/domain/PublishStatus.java
@@ -20,9 +20,9 @@ public enum PublishStatus {
 
     private final String value;
 
-    public static PublishLocation getByValue(String value) {
-        return Arrays.stream(PublishLocation.values())
-                .filter(location -> location.getValue().equals(value))
+    public static PublishStatus getByValue(String value) {
+        return Arrays.stream(PublishStatus.values())
+                .filter(status -> status.getValue().equals(value))
                 .findAny().orElseThrow(() -> new BannerException(BannerFailureCode.NOT_FOUND_STATUS));
     }
 }

--- a/operation-domain/src/test/java/org/sopt/makers/operation/banner/BannerTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/banner/BannerTest.java
@@ -47,13 +47,10 @@ public class BannerTest {
     private static final LocalDate TEST_BANNER_END_DATE = LocalDate.of(2024, 12, 31);
     private static final String TEST_BANNER_PC_IMAGE_URL = "image-url-for-pc";
     private static final String TEST_BANNER_MOBILE_IMAGE_URL = "image-url-for-mobile";
-
-    private static final PublishPeriod TEST_PUBLISH_PERIOD = new PublishPeriod(
-            TEST_BANNER_START_DATE, TEST_BANNER_END_DATE
-    );
-    private static final BannerImage TEST_BANNER_IMAGE = new BannerImage(
-            TEST_BANNER_PC_IMAGE_URL, TEST_BANNER_MOBILE_IMAGE_URL
-    );
+    private static final PublishPeriod TEST_PUBLISH_PERIOD = PublishPeriod.builder()
+            .startDate(TEST_BANNER_START_DATE).endDate(TEST_BANNER_END_DATE).build();
+    private static final BannerImage TEST_BANNER_IMAGE = BannerImage.builder()
+            .pcImageUrl(TEST_BANNER_PC_IMAGE_URL).mobileImageUrl(TEST_BANNER_MOBILE_IMAGE_URL).build();
 
     private static final Banner TEST_BANNER = Banner.builder()
             .location(TEST_BANNER_LOCATION)

--- a/operation-domain/src/test/java/org/sopt/makers/operation/banner/PublishPeriodTest.java
+++ b/operation-domain/src/test/java/org/sopt/makers/operation/banner/PublishPeriodTest.java
@@ -17,7 +17,8 @@ public class PublishPeriodTest {
 
     private static final LocalDate TEST_START_DATE = LocalDate.of(2024,1,1);
     private static final LocalDate TEST_END_DATE = LocalDate.of(2024,12,31);
-    private final PublishPeriod givenPeriod = new PublishPeriod(TEST_START_DATE, TEST_END_DATE);
+    private final PublishPeriod givenPeriod = PublishPeriod.builder()
+            .startDate(TEST_START_DATE).endDate(TEST_END_DATE).build();
 
     @ParameterizedTest(name = "({index}) date : {0} -> result : {1}")
     @MethodSource("argsForCalculateStatus")


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #297

## Work Description ✏️
- 배너 목록 조회 기능 구현

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->

### ※ Request Parameter 처리
현재 구현된 방향성은 아래와 같습니다.
- Service 인터페이스에 "정렬 기준"(Sort Criteria) / "분류 기준"(Filter Criteria) Enum 클래스를 선언했습니다.
  - 외부의 입력값에 대해 Service 구현체 내부에서 변환하는 것은 "책임이 분리되지 않은 것"이라고 판단했습니다.
  - Controller 단에서 "요청 값 → 비즈니스 로직 가용 값" 변환이 필요하다고 판단했습니다.
  - Criteria Enum의 경우, `#fromParameter`라는 비즈니스 로직 가용 값으로 전환하는 static method를 제공합니다.

<br/>

### ※ 시스템 시간 의존성 제거
주로 요청 시점 기반 동적 연산이 필요한 경우, `LocalDate.now()`/`LocalDateTime.now()`를 통해 현재 시간에 대한 데이터를 조회하게 됩니다.
하지만 위와 같이 구현한 경우, 특정 날짜 값과의 연산이 필요한 기능에 대해 Test를 진행하면 에러가 발생할 확률이 높아진다고 생각합니다.
(실제로 CI 단계에서 에러가 발생하는 것을 발견했습니다.)

이에 따라 `Clock` 객체 주입을 통한 `LocalDate.now()`/`LocalDateTime.now()` 호출 방식으로 변경해 해결했습니다.
이로써 얻게 된 효용은 아래와 같습니다.
- 테스트 진행 시, 테스트에서 의도한 기준 날짜 기반으로 테스트를 진행할 수 있습니다.
- 현재 시스템 상의 시간에 의존적인 코드 구현을 방지할 수 있습니다.

<br/>

### ※ DB 조건부(`where` / `order by`) 조회 vs Stream 중간 연산 (`filter` / `sorted`)
현재 구현 방식은 후자인 "**Stream 중간 연산** (`filter` / `sorted`)"을 채택한 방식입니다.

Application ↔ DB 간 네트워크 속도 최적화 & 할당되는 메모리 절약을 위해 DB에서 최대한 필터링하는 것이 가장 바람직하지만
- 현재 데이터 양은 많지 않은 상황
- 빠른 구현이 필요한 상황

위 두 상황을 이유로 본 작업 내용과 같이 구현하게 되었습니다.

이에 따라 추후에 DB 쿼리를 통해 필요한 데이터만 조회할 수 있도록 개선할 계획입니다.
- [참고 링크 1](https://www.inflearn.com/community/questions/184494/sql-where-%EB%AC%B8-vs-java-stream-filter-%EC%84%B1%EB%8A%A5%EC%B0%A8%EC%9D%B4%EC%97%90-%EA%B4%80%ED%95%9C-%EC%A7%88%EB%AC%B8%EC%9E%85%EB%8B%88%EB%8B%A4?srsltid=AfmBOoqT7WQgBbuSDR5aTJRQ7euEQpazGGOuDac0NgnQbmdx4fxRiolP)
- [참고 링크 2](https://devvkkid.tistory.com/234)

<br/>

### ※ 페이지네이션(Pagination)에 대한 고민
이 또한 위 내용과 동일한 상황적 이유와 함께 "**단순 기본형 타입 필드로 구성된 객체**"라는 이유로 별도 페이지네이션 처리에 대해선 구현하지 않고 전체 배너 정보 리스트를 반환하도록 했습니다.
(+JPA Pagable 전용 메서드까지 추가적인 구현이 필요하기 때문)

하지만 추후 게시하는 배너가 누적될수록 데이터의 양이 방대해지기 때문에 페이지네이션을 고려할 필요가 있습니다.
이에 따라 추후 JPA Pagable 적용을 계획하고 있습니다.

- 실제 배포 이후 "**변경이 적다**"라고 관측된다면 "전체 리스트 Cache" 혹은 "페이지 별 Cache"를 고려하는 것도 좋아보입니다.
  - [참고 링크](https://yeon-kr.tistory.com/177) - 단, 성능 개선 여부는 확인이 필요해보입니다. (Cache를 위한 메모리 할당 vs 조회 시간 단축 Trade-Off 필요)