### PR TITLE
[TEST/#299] 배너 생성 컨트롤러 테스트코드 작성

### DIFF
--- a/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/banner/service/BannerService.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.sopt.makers.operation.web.banner.dto.request.*;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
-import org.sopt.makers.operation.web.banner.dto.response.BannerResponse.BannerDetail;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse.BannerImageUrl;
 
 public interface BannerService {

--- a/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
@@ -1,9 +1,7 @@
 package org.sopt.makers.operation.web.banner.api;
 
 import com.fasterxml.jackson.databind.*;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.*;
 
 import org.sopt.makers.operation.code.success.web.BannerSuccessCode;
 import org.sopt.makers.operation.filter.JwtAuthenticationFilter;
@@ -11,7 +9,6 @@ import org.sopt.makers.operation.filter.JwtExceptionFilter;
 import org.sopt.makers.operation.jwt.JwtTokenProvider;
 import org.sopt.makers.operation.web.banner.dto.request.BannerRequest.*;
 import org.sopt.makers.operation.web.banner.dto.response.BannerResponse;
-import org.sopt.makers.operation.web.banner.dto.response.BannerResponse.*;
 import org.sopt.makers.operation.web.banner.service.BannerService;
 
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,6 +22,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.security.Principal;
 import java.time.LocalDate;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +93,7 @@ class BannerApiControllerTest {
     @DisplayName("(DELETE) Banner Delete")
     void deleteBanner() throws Exception {
         //given
+        bannerService.deleteBanner(MOCK_BANNER_ID);
         BannerResponse.BannerDetail mockBannerDetail =  bannerService.getBannerDetail(MOCK_BANNER_ID);
 
         this.mockMvc.perform(
@@ -105,7 +105,6 @@ class BannerApiControllerTest {
             //then
                 .andExpect(status().isNoContent())
                 .andExpect(jsonPath("$.success").value("true"));
-
     }
 
     @Test
@@ -127,36 +126,38 @@ class BannerApiControllerTest {
                 .andExpect(jsonPath("$.success").value("true"));
     }
 
-    @Test
-    @DisplayName("(POST) New Banner")
-    void createNewBanner() throws Exception {
-        // given
-        BannerCreate bannerCreate = new BannerCreate("pg_community", "product", "publisher",
-                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), "link", "image-url-pc", "image-url-mobile"
-        );
-        String request = objectMapper.writeValueAsString(bannerCreate);
-        BannerDetail givenBannerDetail = bannerService.getBannerDetail(MOCK_BANNER_ID);
-        when(bannerService.createBanner(bannerCreate))
-                .thenReturn(givenBannerDetail);
+    @Nested
+    class CreateBannerTests {
+        @Test
+        @DisplayName("(POST) New Banner")
+        void createNewBanner() throws Exception {
+            // given
+            BannerCreate bannerCreate = new BannerCreate("pg_community", "product", "publisher",
+                    LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), "link", "image-url-pc", "image-url-mobile");
+            BannerResponse.BannerDetail mockBannerDetail = new BannerResponse.BannerDetail(
+                    MOCK_BANNER_ID, "in_progress", "pg_community", "product", "publisher", "link",
+                    LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), "image-url-pc", "image-url-mobile");
+            String request = objectMapper.writeValueAsString(bannerCreate);
+            when(bannerService.createBanner(any(BannerCreate.class))).thenReturn(mockBannerDetail);
 
-        this.mockMvc.perform(
-                // when
-                post("/api/v1/banners")
-                        .contentType(APPLICATION_JSON)
-                        .content(request))
-                // then
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.success").value("true"))
-                .andExpect(jsonPath("$.message").value(BannerSuccessCode.SUCCESS_CREATE_BANNER.getMessage()))
-                .andExpect(jsonPath("$.data.id").value(givenBannerDetail.bannerId()))
-                .andExpect(jsonPath("$.data.status").value(givenBannerDetail.bannerStatus()))
-                .andExpect(jsonPath("$.data.location").value(givenBannerDetail.bannerLocation()))
-                .andExpect(jsonPath("$.data.content_type").value(givenBannerDetail.bannerType()))
-                .andExpect(jsonPath("$.data.publisher").value(givenBannerDetail.publisher()))
-                .andExpect(jsonPath("$.data.link").value(givenBannerDetail.link()))
-                .andExpect(jsonPath("$.data.start_date").value(givenBannerDetail.startDate().toString()))
-                .andExpect(jsonPath("$.data.end_date").value(givenBannerDetail.endDate().toString()))
-                .andExpect(jsonPath("$.data.image_url_pc").value(givenBannerDetail.pcImageUrl()))
-                .andExpect(jsonPath("$.data.image_url_mobile").value(givenBannerDetail.mobileImageUrl()));
+            // when
+            mockMvc.perform(post("/api/v1/banners")
+                            .contentType(APPLICATION_JSON)
+                            .content(request))
+                    // then
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value(BannerSuccessCode.SUCCESS_CREATE_BANNER.getMessage()))
+                    .andExpect(jsonPath("$.data.id").value(mockBannerDetail.bannerId()))
+                    .andExpect(jsonPath("$.data.status").value(mockBannerDetail.bannerStatus()))
+                    .andExpect(jsonPath("$.data.location").value(mockBannerDetail.bannerLocation()))
+                    .andExpect(jsonPath("$.data.content_type").value(mockBannerDetail.bannerType()))
+                    .andExpect(jsonPath("$.data.publisher").value(mockBannerDetail.publisher()))
+                    .andExpect(jsonPath("$.data.link").value(mockBannerDetail.link()))
+                    .andExpect(jsonPath("$.data.start_date").value(mockBannerDetail.startDate().toString()))
+                    .andExpect(jsonPath("$.data.end_date").value(mockBannerDetail.endDate().toString()))
+                    .andExpect(jsonPath("$.data.image_url_pc").value(mockBannerDetail.pcImageUrl()))
+                    .andExpect(jsonPath("$.data.image_url_mobile").value(mockBannerDetail.mobileImageUrl()));
+        }
     }
 }

--- a/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
@@ -139,10 +139,12 @@ class BannerApiControllerTest {
         when(bannerService.createBanner(bannerCreate))
                 .thenReturn(givenBannerDetail);
 
-        // when & then
-        this.mockMvc.perform(post("/api/v1/banners")
+        this.mockMvc.perform(
+                // when
+                post("/api/v1/banners")
                         .contentType(APPLICATION_JSON)
                         .content(request))
+                // then
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value("true"))
                 .andExpect(jsonPath("$.message").value(BannerSuccessCode.SUCCESS_CREATE_BANNER.getMessage()))

--- a/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
+++ b/operation-api/src/test/java/org/sopt/makers/operation/web/banner/api/BannerApiControllerTest.java
@@ -93,8 +93,7 @@ class BannerApiControllerTest {
     @DisplayName("(DELETE) Banner Delete")
     void deleteBanner() throws Exception {
         //given
-        bannerService.deleteBanner(MOCK_BANNER_ID);
-        BannerResponse.BannerDetail mockBannerDetail =  bannerService.getBannerDetail(MOCK_BANNER_ID);
+        doNothing().when(bannerService).deleteBanner(MOCK_BANNER_ID);
 
         this.mockMvc.perform(
             //when


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #299

## Work Description ✏️
- 배너 생성 작업에 대한 컨트롤러 단 테스트코드를 작성했습니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 오빠들이 작업한 API는 모두 `when(bannerService.getBannerDetail(MOCK_BANNER_ID)).thenReturn(mockBannerDetail);` 부분에서 모킹한 getBannerDetail 메서드를 사용하고 있는데요 이 부분이 현재 모든 테스트 실행 이전에 동작하는 `@BeforeEach`에 정의되어 있습니다
- 그러나 제 API는 생성과 관련되어 있기 때문에 해당 부분이 필요 없다는 생각이 들었습니다 그래서 서비스 단 모킹 코드를 각 테스트에서 진행하는 것은 어떤지 궁금합니다
- 현재는 제 코드에서 이미 모킹이 진행된다는 가정하에 getBannerDetail을 사용하긴 했는데, 이 과정 없이 givenBannerDetail의 값과 비교하는 과정만으로도 충분한 테스트가 진행된다고 생각해요 오빠들의 생각이 궁금합니다!
- 그리고 현욱오빠 테스트코드에서 (DELETE) Banner Detail 부분에 mockBannerDetail 변수는 필요없는 코드인 것 같은데 어떻게 생각하시나요?