### PR TITLE
[FIX] 알림 한글 깨짐 이슈 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ ENV PROFILE=${PROFILE}
 
 EXPOSE 8080
 ENTRYPOINT ["java"]
-CMD ["-jar", "operation.jar"]
+CMD ["-Dfile.encoding=UTF-8", "-jar", "operation.jar"]

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/InstantAlarmSender.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/InstantAlarmSender.java
@@ -62,9 +62,9 @@ class InstantAlarmSender implements AlarmSender{
     }
 
     private static void putOptionalAttributes(InstantAlarmRequest instantRequest, HashMap<Object, Object> body) {
-        val isTargetAll = instantRequest.targetType().equals(AlarmTargetType.ALL);
-        val isWebLink = instantRequest.linkType().equals(AlarmLinkType.WEB);
-        val isAppLink = instantRequest.linkType().equals(AlarmLinkType.APP);
+        val isTargetAll = Objects.equals(instantRequest.targetType(), AlarmTargetType.ALL);
+        val isWebLink = Objects.equals(instantRequest.linkType(), AlarmLinkType.WEB);
+        val isAppLink = Objects.equals(instantRequest.linkType(), AlarmLinkType.APP);
 
         if (!isTargetAll) {
             body.put("userIds", instantRequest.targets());
@@ -79,7 +79,9 @@ class InstantAlarmSender implements AlarmSender{
     private HttpHeaders generateHeader(InstantAlarmRequest instantRequest) {
         val headers = new HttpHeaders();
         val apiKey = valueConfig.getNOTIFICATION_KEY();
-        val actionValue = instantRequest.targetType().getAction().getValue();
+        val actionValue = instantRequest.targetType() != null && instantRequest.targetType().getAction() != null
+                ? instantRequest.targetType().getAction().getValue()
+                : AlarmSendAction.SEND.getValue();
 
         headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
         headers.setAccept(Collections.singletonList(APPLICATION_JSON));

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/InstantAlarmSender.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/InstantAlarmSender.java
@@ -3,6 +3,7 @@ package org.sopt.makers.operation.client.alarm;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.makers.operation.alarm.domain.AlarmLinkType;
+import org.sopt.makers.operation.alarm.domain.AlarmSendAction;
 import org.sopt.makers.operation.alarm.domain.AlarmTargetType;
 import org.sopt.makers.operation.client.alarm.dto.AlarmRequest;
 import org.sopt.makers.operation.client.alarm.dto.InstantAlarmRequest;
@@ -10,14 +11,17 @@ import org.sopt.makers.operation.config.ValueConfig;
 import org.sopt.makers.operation.exception.AlarmException;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.UUID.randomUUID;
 import static org.sopt.makers.operation.code.failure.AlarmFailureCode.FAIL_SEND_ALARM;
@@ -77,7 +81,7 @@ class InstantAlarmSender implements AlarmSender{
         val apiKey = valueConfig.getNOTIFICATION_KEY();
         val actionValue = instantRequest.targetType().getAction().getValue();
 
-        headers.setContentType(APPLICATION_JSON);
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
         headers.setAccept(Collections.singletonList(APPLICATION_JSON));
 
         headers.add("action", actionValue);


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

[FEAT] 새로운 기능을 개발하거나 추가, 변경할 경우(spring boot 내의 기능 코드) 
[FIX] 버그를 발견하여 코드를 수정한 경우(spring boot 내의 기능 코드)
[REFACTOR] 코드의 효율/가독성을 위해 수정한 경우
[CHORE] 업무적 기능과 무관한, 자잘한 정비 작업 ex) 패키지 구조 및 파일 이름 수정, 로그 레벨 조정 등 작은 설정
[INFRA] docker, nginx와 관련되어 CD 로직을 수정하는 경우
[DOCS] README, Swagger관련  수정하는 경우
[SETTING] 프로젝트에 세팅을 하는 경우 (ex. 초기 세팅, 오픈소스 도입 등)
-->

## Related Issue 🚀
- closed #340 
- related to #340 

## Work Description ✏️
- RestTemplate으로 알림 서버에 요청을 보낼 때 Content-Type 헤더에 UTF-8 charset을 추가했습니다.
- Docker 실행 시 JVM 인코딩을 utf-8로 설정했습니다 (dockerfile 수정)
- 알림 요청 시 instantRequest 에 비어있는 필드에 접근할 때 NullPointerException이 발생하여 예외처리를 추가했습니다

## PR Point 📸
로컬에서는 알림 깨짐없이 잘 가는 것 확인했습니다! 