### PR TITLE
[FIX] 알림 어드민: 활동기수 + 전체 파트로 전송 시 dev 테이블에서 존재하지 않는 Part가 존재하지 않는 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,3 +53,7 @@ jar {
 bootJar {
     enabled = false
 }
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs += ['-parameters']
+}

--- a/operation-api/src/main/java/org/sopt/makers/operation/common/config/SwaggerConfig.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/common/config/SwaggerConfig.java
@@ -14,33 +14,37 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @SecurityScheme(
-		name = "Authorization",
-		type = SecuritySchemeType.HTTP,
-		in = SecuritySchemeIn.HEADER,
-		bearerFormat = "JWT",
-		scheme = "Bearer"
+        name = "Authorization",
+        type = SecuritySchemeType.HTTP,
+        in = SecuritySchemeIn.HEADER,
+        bearerFormat = "JWT",
+        scheme = "Bearer"
 )
 @Configuration
 public class SwaggerConfig {
 
-	@Bean
+    @Bean
     public OpenAPI api() {
+        Server localServer = new Server()
+                .url("http://localhost:8080")
+                .description("Localhost Server");
+
         Server httpsServer = new Server()
-            .url("https://operation.api.dev.sopt.org")
-            .description("HTTPS Server");
+                .url("https://operation.api.dev.sopt.org")
+                .description("HTTPS Server");
 
         Info info = new Info()
-            .title("Makers Operation API Docs")
-            .version("v2.0")
-            .description("운영 프로덕트 API 명세서 입니다.");
+                .title("Makers Operation API Docs")
+                .version("v2.0")
+                .description("운영 프로덕트 API 명세서 입니다.");
 
         SecurityRequirement securityRequirement = new SecurityRequirement().addList("Authorization");
 
 
 
         return new OpenAPI()
-            .info(info)
-            .servers(List.of(httpsServer))
+                .info(info)
+                .servers(List.of(localServer, httpsServer))
                 .addSecurityItem(securityRequirement);
     }
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

[FEAT] 새로운 기능을 개발하거나 추가, 변경할 경우(spring boot 내의 기능 코드) 
[FIX] 버그를 발견하여 코드를 수정한 경우(spring boot 내의 기능 코드)
[REFACTOR] 코드의 효율/가독성을 위해 수정한 경우
[CHORE] 업무적 기능과 무관한, 자잘한 정비 작업 ex) 패키지 구조 및 파일 이름 수정, 로그 레벨 조정 등 작은 설정
[INFRA] docker, nginx와 관련되어 CD 로직을 수정하는 경우
[DOCS] README, Swagger관련  수정하는 경우
[SETTING] 프로젝트에 세팅을 하는 경우 (ex. 초기 세팅, 오픈소스 도입 등)
-->

## Related Issue 🚀
- closed #343 
- related to #343

## Work Description ✏️
- `to-be` : member 테이블에서 회원 조회 시 Part에 회장/부회장/총무/메이커스 팀장 등 정의되지 않은 문자열이 들어가 있는 케이스가 있어 500 에러가 발생했습니다
- 이를 해결하기 위해 dev/prod 테이블 데이터를 확인했으며 dev 환경에서만 해당 데이터가 존재하고 있음을 확인했고, dev에서 해당 데이터를 삭제하였습니다
- 또한 localhost에서 swagger 테스트를 진행할 수 없어 관련 설정을 수정해주었습니다


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
![image](https://github.com/user-attachments/assets/a175a485-abdc-4696-96f7-f275565066ed)
