### PR TITLE
[FEAT] 인증중앙화 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@
 -->
 
 ## Related Issue 🚀
-- closed #{이슈_번호
 - related to #{이슈_번호}
 
 ## Work Description ✏️

--- a/operation-api/src/main/java/org/sopt/makers/operation/OperationApplication.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/OperationApplication.java
@@ -1,8 +1,11 @@
 package org.sopt.makers.operation;
 
+import org.sopt.makers.operation.client.auth.AuthClientProperty;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
+@EnableConfigurationProperties(AuthClientProperty.class)
 @SpringBootApplication(
 		scanBasePackageClasses = {AuthRoot.class, CommonRoot.class, DomainRoot.class, ExternalRoot.class}
 )

--- a/operation-api/src/main/java/org/sopt/makers/operation/test/UserInfoController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/test/UserInfoController.java
@@ -1,16 +1,13 @@
 package org.sopt.makers.operation.test;
 
-
 import lombok.RequiredArgsConstructor;
 import org.sopt.makers.operation.authentication.MakersAuthentication;
 import org.sopt.makers.operation.client.auth.AuthClient;
 import org.sopt.makers.operation.client.auth.AuthClientProperty;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import java.util.Map;
 
 @RestController
@@ -30,6 +27,4 @@ public class UserInfoController {
         );
         System.out.println();
     }
-
 }
-

--- a/operation-api/src/main/java/org/sopt/makers/operation/test/UserInfoController.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/test/UserInfoController.java
@@ -1,0 +1,35 @@
+package org.sopt.makers.operation.test;
+
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.operation.authentication.MakersAuthentication;
+import org.sopt.makers.operation.client.auth.AuthClient;
+import org.sopt.makers.operation.client.auth.AuthClientProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/me")
+@RequiredArgsConstructor
+public class UserInfoController {
+
+    private final AuthClientProperty authProperty;
+    private final AuthClient authClient;
+
+    @GetMapping
+    public void getCurrentUserInfo(Authentication authentication) {
+        MakersAuthentication makers = (MakersAuthentication) authentication;
+        Map<String, Object> response = Map.of(
+                "userId", makers.getUserId(),
+                "roles", makers.getRoles()
+        );
+        System.out.println();
+    }
+
+}
+

--- a/operation-api/src/main/resources/application-dev.yml
+++ b/operation-api/src/main/resources/application-dev.yml
@@ -87,7 +87,7 @@ official:
 
 external:
   auth:
-    url: https://auth.api.sopt.org
+    url: https://auth.api.dev.sopt.org
     api-key: ${AUTH_API_KEY}
     service-name: ${OUR_SERVICE_NAME}
     endpoints:

--- a/operation-api/src/main/resources/application-dev.yml
+++ b/operation-api/src/main/resources/application-dev.yml
@@ -31,6 +31,8 @@ spring:
       access: ${JWT_SECRET_KEY_ACCESS}
       refresh: ${JWT_SECRET_KEY_REFRESH}
       platform_code: ${JWT_SECRET_PLATFORM_CODE}
+    jwk:
+      issuer : ${MAKERS_AUTH_JWK_ISSUER}
   secretKey:
     playground: ${SECRET_KEY_PG}
 
@@ -82,3 +84,11 @@ management:
 
 official:
   apikey: ${APK_KEY}
+
+external:
+  auth:
+    url: https://auth.api.sopt.org
+    api-key: ${AUTH_API_KEY}
+    service-name: ${OUR_SERVICE_NAME}
+    endpoints:
+      jwk: ${MAKERS_AUTH_JWK_ENDPOINT}

--- a/operation-auth/build.gradle
+++ b/operation-auth/build.gradle
@@ -18,5 +18,12 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
     implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.1'
 
+
+    // 새로운 JWT & 캐싱 라이브러리
+    implementation("com.nimbusds:nimbus-jose-jwt:9.37.3")
+    implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
+
+
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
 }

--- a/operation-auth/build.gradle
+++ b/operation-auth/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     implementation project(':operation-common')
     implementation project(':operation-external')
 
-
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
@@ -20,12 +19,9 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
     implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.1'
 
-
     // 새로운 JWT & 캐싱 라이브러리
     implementation("com.nimbusds:nimbus-jose-jwt:9.37.3")
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
-
-
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
 }

--- a/operation-auth/build.gradle
+++ b/operation-auth/build.gradle
@@ -8,6 +8,8 @@ bootJar {
 
 dependencies {
     implementation project(':operation-common')
+    implementation project(':operation-external')
+
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/operation-auth/src/main/java/org/sopt/makers/operation/authentication/MakersAuthentication.java
+++ b/operation-auth/src/main/java/org/sopt/makers/operation/authentication/MakersAuthentication.java
@@ -1,0 +1,66 @@
+package org.sopt.makers.operation.authentication;
+
+
+import lombok.Getter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class MakersAuthentication implements Authentication {
+
+    private final String userId;
+    private final List<GrantedAuthority> authorities;
+    private boolean authenticated = false;
+
+    public MakersAuthentication(String userId, List<String> roles) {
+        this.userId = userId;
+        this.authorities = roles.stream()
+                .map(role -> (GrantedAuthority) new SimpleGrantedAuthority(role))
+                .toList();
+    }
+
+    public List<String> getRoles() {
+        return authorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null; // JWT 기반 인증이라 자격 증명 X
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userId;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return authenticated;
+    }
+
+    @Override
+    public void setAuthenticated(boolean authenticated) throws IllegalArgumentException {
+        this.authenticated = authenticated;
+    }
+
+    @Override
+    public String getName() {
+        return userId;
+    }
+}

--- a/operation-auth/src/main/java/org/sopt/makers/operation/authentication/MakersAuthentication.java
+++ b/operation-auth/src/main/java/org/sopt/makers/operation/authentication/MakersAuthentication.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.operation.authentication;
 
-
 import lombok.Getter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;

--- a/operation-auth/src/main/java/org/sopt/makers/operation/jwt/JwkProvider.java
+++ b/operation-auth/src/main/java/org/sopt/makers/operation/jwt/JwkProvider.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.operation.jwt;
 
-
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.nimbusds.jose.JOSEException;

--- a/operation-auth/src/main/java/org/sopt/makers/operation/jwt/JwkProvider.java
+++ b/operation-auth/src/main/java/org/sopt/makers/operation/jwt/JwkProvider.java
@@ -1,0 +1,94 @@
+package org.sopt.makers.operation.jwt;
+
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import java.io.IOException;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import lombok.extern.slf4j.Slf4j;
+
+import org.sopt.makers.operation.client.auth.AuthClient;
+import org.sopt.makers.operation.code.failure.auth.JwkFailure;
+import org.sopt.makers.operation.exception.ClientException;
+import org.sopt.makers.operation.exception.JwkException;
+import org.springframework.stereotype.Component;
+
+
+import java.security.PublicKey;
+import java.time.Duration;
+
+@Slf4j
+@Component
+public class JwkProvider {
+
+    private final Cache<String, PublicKey> keyCache;
+    private final AuthClient authClient;
+
+    public JwkProvider(AuthClient authClient) {
+        this.keyCache = Caffeine.newBuilder()
+                .maximumSize(20)
+                .expireAfterWrite(Duration.ofDays(1))
+                .build();
+        this.authClient = authClient;
+    }
+
+    /**
+     * 주어진 kid에 해당하는 PublicKey 반환
+     * @param kid JWT header의 Key ID
+     * @return RSA PublicKey
+     * @throws JwkException 키 조회 실패 시
+     */
+    public PublicKey getPublicKey(String kid) {
+        return keyCache.get(kid, this::resolvePublicKey);
+    }
+
+    private PublicKey resolvePublicKey(String kid) {
+        try {
+            JWKSet jwkSet = loadJwkSet();
+            JWK jwk = findJwkByKeyId(jwkSet, kid);
+            return convertToPublicKey(jwk);
+        } catch (JwkException | ClientException e) {
+            throw e;
+        } catch (RuntimeException | IOException | ParseException e) {
+            log.error(e.getMessage());
+            throw new JwkException(JwkFailure.JWK_FETCH_FAILED);
+        }
+    }
+
+    private JWKSet loadJwkSet() throws IOException, ParseException, ClientException {
+        String json = authClient.getJwk();
+        return JWKSet.parse(json);
+    }
+
+    private JWK findJwkByKeyId(JWKSet jwkSet, String kid) {
+        return jwkSet.getKeys().stream()
+                .filter(jwk -> kid.equals(jwk.getKeyID()))
+                .findFirst()
+                .orElseThrow(() -> new JwkException(JwkFailure.JWK_KID_NOT_FOUND));
+    }
+
+    private RSAPublicKey convertToPublicKey(JWK jwk) {
+        if (!(jwk instanceof RSAKey rsaKey)) {
+            throw new JwkException(JwkFailure.JWK_INVALID_FORMAT);
+        }
+
+        try {
+            return rsaKey.toRSAPublicKey();
+        } catch (JOSEException e) {
+            throw new JwkException(JwkFailure.JWK_INVALID_FORMAT);
+        }
+    }
+
+    /**
+     * 캐시 무효화 (예: 복호화 실패 시)
+     */
+    public void invalidateKey(String kid) {
+        log.warn("Invalidating cached JWK for kid={}", kid);
+        keyCache.invalidate(kid);
+    }
+}

--- a/operation-auth/src/main/java/org/sopt/makers/operation/jwt/JwtAuthenticationService.java
+++ b/operation-auth/src/main/java/org/sopt/makers/operation/jwt/JwtAuthenticationService.java
@@ -1,0 +1,145 @@
+package org.sopt.makers.operation.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.makers.operation.authentication.MakersAuthentication;
+import org.sopt.makers.operation.code.failure.auth.JwtFailure;
+import org.sopt.makers.operation.exception.JwkException;
+import org.sopt.makers.operation.exception.JwtException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.text.ParseException;
+import java.util.List;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationService {
+
+    private final JwkProvider jwkProvider;
+    private static final String ROLES = "roles";
+
+    @Value("${spring.jwt.jwk.issuer}")
+    private String issuer;
+
+    /**
+     * JWT 토큰을 검증하고, 사용자 인증 정보를 반환합니다.
+     * 내부 동작 순서:
+     * 1. JWT 파싱 (header에서 kid 추출)
+     * 2. JWK Provider에서 공개키 조회
+     * 3. verifyWithRetry를 통해 서명 및 클레임 검증 (재시도 포함)
+     * 4. 검증된 JWTClaimsSet으로부터 {@link MakersAuthentication} 생성
+     *
+     * @param token 서명된 JWT 문자열
+     * @return 인증 정보 객체
+     * @throws JwtException 서명 검증 실패, 파싱 실패, 키 조회 실패 등의 경우
+     */
+    public MakersAuthentication authenticate(String token) {
+        try {
+            SignedJWT jwt = SignedJWT.parse(token);
+            String kid = jwt.getHeader().getKeyID();
+            PublicKey key = jwkProvider.getPublicKey(kid);
+            JWTClaimsSet claims = verifyWithRetry(jwt, kid, key);
+
+            return toAuthentication(claims);
+        } catch (ParseException e) {
+            log.warn("JWT 파싱 실패: {}", e.getMessage());
+            throw new JwtException(JwtFailure.JWT_PARSE_FAILED);
+        } catch (JwkException e) {
+            log.warn("JWT 서명 검증 실패: {}", e.getMessage());
+            throw new JwtException(JwtFailure.JWT_VERIFICATION_FAILED);
+        }
+    }
+
+    /**
+     * JWTClaimsSet을 기반으로 인증 객체를 생성합니다.
+     *
+     * @param claims JWT 내부 클레임
+     * @return 사용자 인증 정보 객체
+     */
+    private MakersAuthentication toAuthentication(JWTClaimsSet claims) {
+        String userId = claims.getSubject();
+        List<String> roles = (List<String>) claims.getClaim(ROLES);
+        return new MakersAuthentication(userId, roles);
+    }
+
+    /**
+     * JWT 검증을 수행하며, 서명 검증 실패 시 1회 재시도를 수행합니다.
+     *
+     * @param jwt 검증할 JWT 객체
+     * @param kid JWT Header의 Key ID
+     * @param publicKey 현재 캐시된 공개키
+     * @return 검증된 JWTClaimsSet
+     */
+    private JWTClaimsSet verifyWithRetry(SignedJWT jwt, String kid, PublicKey publicKey) {
+        try {
+            return verify(jwt, publicKey);
+        } catch (JOSEException | ParseException e) {
+            log.warn("JWT verification failed. reason={}", e.getMessage());
+            return retryVerification(jwt, kid);
+        }
+    }
+
+    /**
+     * JWT 서명 검증 실패 시 캐시된 공개키를 무효화하고,
+     * 인증 서버에서 공개키를 다시 가져와 재검증을 시도하는 로직입니다.
+     * 이 로직은 다음과 같은 상황에 실행됩니다:
+     * - JWK 캐시가 만료되었거나,
+     * - 키 롤링(갱신) 등으로 인해 기존 키로는 서명 검증이 실패하는 경우
+     * 동작 순서:
+     * 1. 기존 키로 검증 시도 → 실패
+     * 2. 캐시 무효화 → JWK 재요청
+     * 3. 새 키로 검증 재시도
+     * 4. 여전히 실패 시 {@link JwtException} 발생
+     *
+     * @param jwt 서명을 검증할 JWT
+     * @param kid JWT 헤더에 포함된 키 ID
+     * @return 검증된 JWTClaimsSet
+     * @throws JwtException 키 재조회 후에도 검증에 실패한 경우
+     */
+    private JWTClaimsSet retryVerification(SignedJWT jwt, String kid) {
+        jwkProvider.invalidateKey(kid);
+        try {
+            PublicKey refreshedKey = jwkProvider.getPublicKey(kid);
+            return verify(jwt, refreshedKey);
+        } catch (JwkException | JOSEException | ParseException e) {
+            log.error("Re-verification failed. reason={}", e.getMessage());
+            throw new JwtException(JwtFailure.JWT_VERIFICATION_FAILED);
+        }
+    }
+
+    /**
+     * JWT의 서명, 발급자(issuer), 만료 시간(expiration)을 검증합니다.
+     *
+     * @param jwt        검증할 JWT
+     * @param publicKey  서명 검증에 사용할 RSA 공개키
+     * @return 검증된 JWTClaimsSet
+     * @throws JOSEException 서명 검증 실패 시
+     * @throws ParseException JWT 클레임 파싱 실패 시
+     * @throws JwtException 클레임 자체가 유효하지 않은 경우 (issuer 불일치, 만료 등)
+     */
+    private JWTClaimsSet verify(SignedJWT jwt, PublicKey publicKey) throws JOSEException, ParseException {
+        JWTClaimsSet claims = jwt.getJWTClaimsSet();
+        JWSVerifier verifier = new RSASSAVerifier((RSAPublicKey) publicKey);
+        boolean signatureValid = jwt.verify(verifier);
+        boolean issuerValid = issuer.equals(claims.getIssuer());
+        boolean notExpired = claims.getExpirationTime().after(new Date());
+
+        if (!(signatureValid && issuerValid && notExpired)) {
+            log.warn("Invalid JWT claims detected. signatureValid={}, issuerValid={}, notExpired={}",
+                    signatureValid, issuerValid, notExpired);
+            throw new JwtException(JwtFailure.JWT_INVALID_CLAIMS);
+        }
+        return claims;
+    }
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/ClientFailure.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/ClientFailure.java
@@ -1,0 +1,19 @@
+package org.sopt.makers.operation.code.failure;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum ClientFailure implements FailureCode {
+    RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 서버 응답 오류"),
+    COMMUNICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"외부 서버 통신 실패");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/ClientFailure.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/ClientFailure.java
@@ -4,8 +4,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-
-
 import static lombok.AccessLevel.PRIVATE;
 
 @Getter

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/JwkFailure.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/JwkFailure.java
@@ -1,0 +1,21 @@
+package org.sopt.makers.operation.code.failure.auth;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.makers.operation.code.failure.FailureCode;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum JwkFailure implements FailureCode {
+    JWK_KID_NOT_FOUND(HttpStatus.UNAUTHORIZED, "해당 kid에 대한 공개키를 찾을 수 없습니다."),
+    JWK_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "JWK 형식이 잘못되어 공개키를 파싱할 수 없습니다."),
+    JWK_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JWK 서버로부터 키를 가져오지 못했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}
+

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/JwtFailure.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/JwtFailure.java
@@ -1,0 +1,22 @@
+package org.sopt.makers.operation.code.failure.auth;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import org.sopt.makers.operation.code.failure.FailureCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum JwtFailure implements FailureCode {
+    JWT_MISSING_AUTH_HEADER(HttpStatus.UNAUTHORIZED, "인증 헤더가 존재하지 않습니다."),
+    JWT_PARSE_FAILED(HttpStatus.UNAUTHORIZED, "잘못된 형식의 JWT입니다."),
+    JWT_INVALID_CLAIMS(HttpStatus.UNAUTHORIZED, "JWT의 클레임이 유효하지 않습니다."),
+    JWT_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "JWT 검증에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}
+

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/PermissionFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/auth/PermissionFailureCode.java
@@ -1,7 +1,8 @@
-package org.sopt.makers.operation.code.failure;
+package org.sopt.makers.operation.code.failure.auth;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.sopt.makers.operation.code.failure.FailureCode;
 import org.springframework.http.HttpStatus;
 
 @Getter

--- a/operation-common/src/main/java/org/sopt/makers/operation/exception/BaseException.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/exception/BaseException.java
@@ -1,0 +1,17 @@
+package org.sopt.makers.operation.exception;
+
+import org.sopt.makers.operation.code.failure.FailureCode;
+
+public abstract class BaseException extends RuntimeException {
+
+    private final FailureCode failure;
+
+    public BaseException(final FailureCode failure) {
+        super(failure.getMessage());
+        this.failure = failure;
+    }
+
+    public FailureCode getError() {
+        return this.failure;
+    }
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/exception/ClientException.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/exception/ClientException.java
@@ -1,0 +1,10 @@
+package org.sopt.makers.operation.exception;
+
+
+import org.sopt.makers.operation.code.failure.ClientFailure;
+
+public class ClientException extends BaseException {
+    public ClientException(ClientFailure failure) {
+        super(failure);
+    }
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/exception/JwkException.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/exception/JwkException.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.operation.exception;
+
+import org.sopt.makers.operation.code.failure.auth.JwkFailure;
+
+public class JwkException extends BaseException {
+    public JwkException(JwkFailure failure) {
+        super(failure);
+    }
+}

--- a/operation-common/src/main/java/org/sopt/makers/operation/exception/JwtException.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/exception/JwtException.java
@@ -1,0 +1,9 @@
+package org.sopt.makers.operation.exception;
+
+import org.sopt.makers.operation.code.failure.auth.JwtFailure;
+
+public class JwtException extends BaseException {
+    public JwtException(JwtFailure failure) {
+        super(failure);
+    }
+}

--- a/operation-external/build.gradle
+++ b/operation-external/build.gradle
@@ -17,6 +17,10 @@ dependencies {
     implementation 'software.amazon.awssdk:scheduler'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'
 
+    // 외부 인증 서버 통신용
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+
 }
 
 test {

--- a/operation-external/build.gradle
+++ b/operation-external/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     // 외부 인증 서버 통신용
     implementation("org.springframework.boot:spring-boot-starter-webflux")
 
-
 }
 
 test {

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/auth/AuthClient.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/auth/AuthClient.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.operation.client.auth;
 
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.makers.operation.code.failure.ClientFailure;
@@ -8,7 +7,6 @@ import org.sopt.makers.operation.exception.ClientException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-
 
 @Slf4j
 @Component

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/auth/AuthClient.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/auth/AuthClient.java
@@ -1,0 +1,37 @@
+package org.sopt.makers.operation.client.auth;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.makers.operation.code.failure.ClientFailure;
+import org.sopt.makers.operation.exception.ClientException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthClient {
+
+    private final WebClient authWebClient;
+    private final AuthClientProperty authProperty;
+
+    public String getJwk() {
+        try {
+            return authWebClient.get()
+                    .uri(authProperty.endpoints().jwk())
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .onErrorMap(WebClientResponseException.class, ex -> {
+                        log.error("Failed to receive response from Auth server: {}", ex.getResponseBodyAsString(), ex);
+                        return new ClientException(ClientFailure.RESPONSE_ERROR);
+                    })
+                    .block();
+        } catch (RuntimeException e) {
+            log.error("Unexpected exception occurred during Auth server communication: {}", e.getMessage(), e);
+            throw new ClientException(ClientFailure.COMMUNICATION_ERROR);
+        }
+    }
+}

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/auth/AuthClientProperty.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/auth/AuthClientProperty.java
@@ -1,0 +1,13 @@
+package org.sopt.makers.operation.client.auth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "external.auth")
+public record AuthClientProperty(
+        String url,
+        String apiKey,
+        String serviceName,
+        Endpoints endpoints
+) {
+    public record Endpoints(String jwk) {}
+}

--- a/operation-external/src/main/java/org/sopt/makers/operation/config/AuthWebClientConfig.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/config/AuthWebClientConfig.java
@@ -1,0 +1,47 @@
+package org.sopt.makers.operation.config;
+
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.sopt.makers.operation.client.auth.AuthClientProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+
+import java.time.Duration;
+
+@Configuration
+public class AuthWebClientConfig {
+
+    public static final String HEADER_API_KEY = "X-Api-Key";
+    public static final String HEADER_SERVICE_NAME = "X-Service-Name";
+    private static final int TIMEOUT_MILLIS = 5000;
+    private static final int TIMEOUT_SECONDS = 5;
+
+    @Bean
+    public WebClient authWebClient(AuthClientProperty property) {
+        return WebClient.builder()
+                .baseUrl(property.url())
+                .clientConnector(new ReactorClientHttpConnector(createDefaultHttpClient()))
+                .defaultHeader(HEADER_API_KEY, property.apiKey())
+                .defaultHeader(HEADER_SERVICE_NAME, property.serviceName())
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    private HttpClient createDefaultHttpClient() {
+        return HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, TIMEOUT_MILLIS)
+                .responseTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(TIMEOUT_SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(TIMEOUT_SECONDS))
+                );
+    }
+}

--- a/operation-external/src/main/java/org/sopt/makers/operation/config/AuthWebClientConfig.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/config/AuthWebClientConfig.java
@@ -1,6 +1,5 @@
 package org.sopt.makers.operation.config;
 
-
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
@@ -12,7 +11,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
-
 
 import java.time.Duration;
 


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

[FEAT] 새로운 기능을 개발하거나 추가, 변경할 경우(spring boot 내의 기능 코드) 
[FIX] 버그를 발견하여 코드를 수정한 경우(spring boot 내의 기능 코드)
[REFACTOR] 코드의 효율/가독성을 위해 수정한 경우
[CHORE] 업무적 기능과 무관한, 자잘한 정비 작업 ex) 패키지 구조 및 파일 이름 수정, 로그 레벨 조정 등 작은 설정
[INFRA] docker, nginx와 관련되어 CD 로직을 수정하는 경우
[DOCS] README, Swagger관련  수정하는 경우
[SETTING] 프로젝트에 세팅을 하는 경우 (ex. 초기 세팅, 오픈소스 도입 등)
-->

## Related Issue 🚀
- related to #357 

## Work Description ✏️
### 인증 중앙화 순서 다이어그램
![인증 중앙화 적용순서도](https://github.com/user-attachments/assets/23145393-d242-43c1-a83d-25b39f0e63d9)


## 추가된 인증 필터 동작 
- 앱에서 어드민으로 api 호출
- jwt 필터 작동 → jwt 서비스  authenticate(토큰) 실행
    1. *JWT 파싱 (header에서 kid 추출)*
    2. *JWK Provider에서 공개키 조회* `getPublicKey`
        1. 캐시에서 퍼블릭 키 조회
            1. 실패시 `resolvePublicKey` 실행 
            2. 인증서버로 부터 JWK 조회 `loadJwkSet()` → `authClient.getJwk()`
    3. verifyWithRetry를 통해 서명 및 클레임 검증 (재시도 포함)
        1. 검증된 JWTClaimSet 반환( **내부에 유저 데이터** )
    4.  *검증된 JWTClaimsSet으로부터 MakersAuthentication} 생성*



### JWT 인증 필터 동작 상세
**1. JwtAuthenticationFilter → jwtAuthenticationService**
-  Authorization 헤더 토큰 추출
- kid 및 issuer 존재 확인
- authenticate(token) 실행

**2. jwtAuthenticationService → JwkProvider**
- JWT 파싱 (header에서 kid 추출)
- JWK Provider에서 공개키 조회 getPublicKey(kid) 실행

**2.JwkProvider → AuthClient(캐시 Miss)**
- 인증 서버로부터 JWK(JSON Web Key) Set 조회 (공개키들 데이터 포함)
- kid로 특정 JWK 찾아서 반환

**4.  JwkProvider -> jwtAuthenticationService**
- JWK를 Java의 RSAPublicKey 객체로 변환
- JWT 검증에 사용 가능한 형태로 공개키 반환

**5. jwtAuthenticationService → Filter**

- verifyWithRetry를 통해 서명 및 클레임 검증 (재시도 포함)
  - RSA 공개키로 JWT 토큰 서명 검증 
  - issuer(발급자) 검증
  - 토큰 만료 시간 검증
  - JWT의 sub 클레임에서 사용자 ID 추출
- 검증된 JWTClaimsSet으로부터 MakersAuthentication 생성

**7. SecurityContext에 인증 객체 저장**



## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 앱에서 호출하는 API에 대한 인증 로직이 추가 수정 되었습니다 !
  - 기존에는 api/v1/app으로 시작하는 url을 확인하여 토큰 타입을 부여했지만 변경될 인증 로직에는 kid와 issuer를 확인합니다 !
-  정기 세미나가 3회 남아있는것을 고려하여 , 앱 api 관련 인증 로직을 한번에 변경하지 않고 기존 인증 로직과 새로운 인증로직 모두 동작하도록 개발해놓았습니다.
    - 인증 서버 Q/A 중 원활한 대처를 위해 로깅 및 주석을 제거하지 않았습니다. 
    - 최종 Q/A 이후 관련 불필요한 코드들을 정리할 예정입니다.
- 시크릿값 4개가 추가 되었습니다.
  - MAKERS_AUTH_JWK_ENDPOINT
  - MAKERS_AUTH_JWK_ISSUER
  - AUTH_API_KEY
  - OUR_SERVICE_NAME
- WebClient 및 캐싱, JWK 파싱을 위해 의존성이 추가 되었습니다.
  - `("com.github.ben-manes.caffeine:caffeine:3.1.8")`
  - `("com.nimbusds:nimbus-jose-jwt:9.37.3")`
  - `("org.springframework.boot:spring-boot-starter-webflux")` 