### PR TITLE
[FEAT/#359] 알림 삭제 시 예약 알림일 경우 EventBridge에서 예약된 일정 삭제 로직 구현하도록 변경

### DIFF
--- a/operation-api/src/main/java/org/sopt/makers/operation/web/alarm/api/AlarmApi.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/alarm/api/AlarmApi.java
@@ -107,7 +107,7 @@ public interface AlarmApi {
             summary = "알림 삭제 API",
             responses = {
                     @ApiResponse(
-                            responseCode = "200",
+                            responseCode = "204",
                             description = "알림 삭제 성공"
                     ),
                     @ApiResponse(

--- a/operation-api/src/main/java/org/sopt/makers/operation/web/alarm/service/AlarmServiceImpl.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/web/alarm/service/AlarmServiceImpl.java
@@ -96,7 +96,12 @@ public class AlarmServiceImpl implements AlarmService {
     @Transactional
     public void deleteAlarm(long alarmId) {
         val alarm = findAlarm(alarmId);
+        val isScheduledAlarm = alarm.getStatus().equals(AlarmStatus.SCHEDULED);
+
         alarmRepository.delete(alarm);
+        if (isScheduledAlarm) {
+            alarmManager.deleteSchedule(alarmId, alarm.getIntendedAt());
+        }
     }
 
     @Override

--- a/operation-common/src/main/java/org/sopt/makers/operation/code/failure/AlarmFailureCode.java
+++ b/operation-common/src/main/java/org/sopt/makers/operation/code/failure/AlarmFailureCode.java
@@ -19,6 +19,7 @@ public enum AlarmFailureCode implements FailureCode {
     INVALID_SCHEDULE_ALARM_FORMAT(BAD_REQUEST, "알림 예약 시간 포맷이 맞지 않습니다."),
     FAIL_SEND_ALARM(BAD_REQUEST, "알림 즉시 발송에 실패하였습니다."),
     FAIL_SCHEDULE_ALARM(BAD_REQUEST, "알림 예약 발송에 실패하였습니다."),
+    FAIL_DELETE_SCHEDULE_ALARM(BAD_REQUEST, "예약 알림 삭자에 실패하였습니다."),
 
     // 404
     NOT_FOUND_ALARM(NOT_FOUND, "알림이 존재하지 않습니다."),

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/AlarmManager.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/AlarmManager.java
@@ -1,24 +1,30 @@
 package org.sopt.makers.operation.client.alarm;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.makers.operation.alarm.domain.Alarm;
+
 import org.sopt.makers.operation.client.alarm.dto.InstantAlarmRequest;
 import org.sopt.makers.operation.client.alarm.dto.ScheduleAlarmRequest;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
 public class AlarmManager {
     private final InstantAlarmSender instantAlarmSender;
     private final ScheduleAlarmSender scheduleAlarmSender;
+    private final ScheduleAlarmDeleter scheduleAlarmDeleter;
 
     public void sendInstant(InstantAlarmRequest alarmRequest) {
         instantAlarmSender.sendAlarm(alarmRequest);
     }
+
     public void sendSchedule(ScheduleAlarmRequest alarmRequest) {
         scheduleAlarmSender.sendAlarm(alarmRequest);
+    }
+
+    public void deleteSchedule(long alarmId, LocalDateTime scheduleDateTime) {
+        scheduleAlarmDeleter.deleteAlarm(alarmId, scheduleDateTime);
     }
 
 }

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/ScheduleAlarmDeleter.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/ScheduleAlarmDeleter.java
@@ -1,0 +1,57 @@
+package org.sopt.makers.operation.client.alarm;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import org.springframework.stereotype.Component;
+
+import org.sopt.makers.operation.config.ValueConfig;
+import org.sopt.makers.operation.code.failure.AlarmFailureCode;
+import org.sopt.makers.operation.exception.AlarmException;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.scheduler.SchedulerClient;
+import software.amazon.awssdk.services.scheduler.model.DeleteScheduleRequest;
+
+import jakarta.annotation.PostConstruct;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.sopt.makers.operation.constant.AlarmConstant.ALARM_REQUEST_DATE_FORMAT;
+import static org.sopt.makers.operation.constant.AlarmConstant.ALARM_REQUEST_SCHEDULE_TIME_FORMAT;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduleAlarmDeleter {
+
+    private final ValueConfig valueConfig;
+    private SchedulerClient schedulerClient;
+
+    @PostConstruct
+    private void init() {
+        val awsCredentials = AwsBasicCredentials.create(valueConfig.getAccessKey(), valueConfig.getSecretKey());
+        this.schedulerClient = SchedulerClient.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+
+    public void deleteAlarm(long alarmId, LocalDateTime scheduleDateTime) {
+        try {
+            val eventName = generateEventName(alarmId, scheduleDateTime);
+            schedulerClient.deleteSchedule(DeleteScheduleRequest.builder()
+                    .name(eventName)
+                    .build());
+        } catch (RuntimeException e) {
+            throw new AlarmException(AlarmFailureCode.FAIL_DELETE_SCHEDULE_ALARM);
+        }
+    }
+
+    private String generateEventName(long alarmId, LocalDateTime scheduleDateTime) {
+        val dateData = scheduleDateTime.toLocalDate().format(DateTimeFormatter.ofPattern(ALARM_REQUEST_DATE_FORMAT));
+        val timeData = scheduleDateTime.toLocalTime().format(DateTimeFormatter.ofPattern(ALARM_REQUEST_SCHEDULE_TIME_FORMAT));
+        return String.format("%s_%s_%d", dateData, timeData, alarmId);
+    }
+}

--- a/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/ScheduleAlarmSender.java
+++ b/operation-external/src/main/java/org/sopt/makers/operation/client/alarm/ScheduleAlarmSender.java
@@ -61,7 +61,6 @@ class ScheduleAlarmSender implements AlarmSender{
             val createScheduleRequest = generateEvent(name, target, cronExpression);
             schedulerClient.createSchedule(createScheduleRequest);
         } catch (Exception e) {
-            e.printStackTrace();
             throw new AlarmException(AlarmFailureCode.FAIL_SCHEDULE_ALARM);
         }
     }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

[FEAT] 새로운 기능을 개발하거나 추가, 변경할 경우(spring boot 내의 기능 코드) 
[FIX] 버그를 발견하여 코드를 수정한 경우(spring boot 내의 기능 코드)
[REFACTOR] 코드의 효율/가독성을 위해 수정한 경우
[CHORE] 업무적 기능과 무관한, 자잘한 정비 작업 ex) 패키지 구조 및 파일 이름 수정, 로그 레벨 조정 등 작은 설정
[INFRA] docker, nginx와 관련되어 CD 로직을 수정하는 경우
[DOCS] README, Swagger관련  수정하는 경우
[SETTING] 프로젝트에 세팅을 하는 경우 (ex. 초기 세팅, 오픈소스 도입 등)
-->

## Related Issue 🚀
- related to #359

## Work Description ✏️
- 알림 삭제 요청 시 해당 알림이 예약 알림일 경우에 EventBridge에 등록된 일정도 함께 삭제되도록 로직을 변경했습니다
- aws와 통신해야하는 로직에 있어, sender와 deleter로 클래스를 나누어 구현해주었습니다
  - Remover로 클래스 이름을 지을까 고민했는데 삭제라는 행위에 대해 remove, delete를 혼용하여 사용하는 것이 클린코드에서 지양해야 할 부분이라 deleter로 이름을 지어보았습니다 
- swagger에 알림 삭제 status가 200으로 잘못 기입되어 있어 204로 수정해주었습니다

### 아래는 기능 테스트 결과입니다
- **step 1: 알림 생성**
<img width="700" alt="스크린샷 2025-07-28 오후 5 42 00" src="https://github.com/user-attachments/assets/34bb4684-9ac3-4e49-a75e-2cc045bf5647" />

- **step 2: 예약된 일정 확인**
<img width="700" alt="스크린샷 2025-07-28 오후 5 40 43" src="https://github.com/user-attachments/assets/56cfcb62-dbf7-45be-9068-35adea296560" />

- **step 3: 알림 삭제**
<img width="700" alt="스크린샷 2025-07-28 오후 5 41 43" src="https://github.com/user-attachments/assets/66958ddc-dd3d-4ec6-8849-3e8c519c29f4" />

- **step 4: 예약된 일정 삭제 확인**
<img width="700" alt="스크린샷 2025-07-28 오후 5 42 44" src="https://github.com/user-attachments/assets/4ecbc29c-fa85-4ac3-a884-eedd2acefd50" />

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
