### PR TITLE
[FEAT] LambdaHandler 클래스 생성

### DIFF
--- a/operation-api/src/main/java/org/sopt/makers/operation/LambdaHandler.java
+++ b/operation-api/src/main/java/org/sopt/makers/operation/LambdaHandler.java
@@ -1,0 +1,39 @@
+package org.sopt.makers.operation;
+
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+import com.amazonaws.serverless.proxy.spring.SpringBootLambdaContainerHandler;
+import com.amazonaws.serverless.exceptions.ContainerInitializationException;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * AWS Lambda 진입점 핸들러
+ *
+ * API Gateway 요청을 Spring Boot Controller로 라우팅합니다.
+ * SnapStart를 통해 Cold Start 시간을 최소화합니다.
+ */
+public class LambdaHandler implements RequestStreamHandler {
+
+    private static SpringBootLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler;
+
+    static {
+        try {
+            handler = SpringBootLambdaContainerHandler.getAwsProxyHandler(OperationApplication.class);
+        } catch (ContainerInitializationException e) {
+            throw new RuntimeException("Could not initialize Spring Boot application", e);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not initialize Lambda handler", e);
+        }
+    }
+
+    @Override
+    public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
+            throws IOException {
+        handler.proxyStream(inputStream, outputStream, context);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Related to #396

## 📋 작업 내용 요약

AWS Lambda의 진입점 역할을 하는 `LambdaHandler` 클래스를 생성합니다.

### 주요 변경사항

- `LambdaHandler.java` 클래스 신규 생성
- `SpringBootLambdaContainerHandler`를 통해 API Gateway ↔ Spring Boot 연동
- SnapStart 지원을 위한 static 초기화 블록 구성

### Handler 동작 방식
```
API Gateway Request
       ↓
LambdaHandler.handleRequest()
       ↓
SpringBootLambdaContainerHandler
       ↓
OperationApplication (Spring Boot)
       ↓
Controller → Service → Repository
       ↓
Response
```

### 추가된 파일

- `operation-api/src/main/java/org/sopt/makers/operation/LambdaHandler.java`

## 🧪 테스트

- [x] `./gradlew :operation-api:compileJava` 성공
- [x] `./gradlew :operation-api:lambdaJar -x test` 성공
- [x] 기존 bootJar 빌드 영향 없음

## ⚠️ 주의사항

- [x] Breaking Change 없음
- [x] 기존 CI/CD 파이프라인 영향 없음
- [x] 기존 OperationApplication.java 수정 없음

## 📚 참고

- [SpringBootLambdaContainerHandler 문서](https://github.com/awslabs/aws-serverless-java-container/wiki/Quick-start---Spring-Boot3)
- Lambda 마이그레이션 Epic #[Epic 이슈번호]

<img width="389" height="252" alt="image" src="https://github.com/user-attachments/assets/86229c88-aeb4-4c75-8b85-94ddf3bf9682" />
