### PR TITLE
[FEAT] SecurityConfig Lambda 프로파일 추가

### DIFF
--- a/operation-auth/src/main/java/org/sopt/makers/operation/config/SecurityConfig.java
+++ b/operation-auth/src/main/java/org/sopt/makers/operation/config/SecurityConfig.java
@@ -52,6 +52,28 @@ public class SecurityConfig {
         return http.build();
     }
 
+    // ✨ Lambda Dev 환경용 SecurityFilterChain 추가
+    @Bean
+    @Profile("lambda-dev")
+    public SecurityFilterChain filterChainLambdaDev(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
+                .requestMatchers(new AntPathRequestMatcher("/swagger-ui/**")).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/v3/**")).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/api/v1/banners/images", "GET")).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/api/v1/banners/images", "OPTIONS")).permitAll()
+        );
+        setHttp(http);
+        return http.build();
+    }
+
+    // ✨ Lambda Prod 환경용 SecurityFilterChain 추가
+    @Bean
+    @Profile("lambda-prod")
+    public SecurityFilterChain filterChainLambdaProd(HttpSecurity http) throws Exception {
+        setHttp(http);
+        return http.build();
+    }
+
     private void setHttp(HttpSecurity http) throws Exception {
         http.httpBasic().disable()
                 .csrf().disable()


### PR DESCRIPTION
## 🔗 관련 이슈

Related to #400 

## 📋 작업 내용 요약

SecurityConfig에 Lambda 환경용 프로파일(`lambda-dev`, `lambda-prod`)을 추가합니다.

### 주요 변경사항

- `filterChainLambdaDev` 메서드 추가 (`@Profile("lambda-dev")`)
- `filterChainLambdaProd` 메서드 추가 (`@Profile("lambda-prod")`)
- 기존 `dev`, `prod` 프로파일 영향 없음

### 프로파일별 설정

| 프로파일 | Swagger 허용 | 용도 |
|----------|-------------|------|
| dev | ✅ | EC2 개발 환경 |
| prod | ❌ | EC2 운영 환경 |
| lambda-dev | ✅ | Lambda 개발 환경 |
| lambda-prod | ❌ | Lambda 운영 환경 |

### 수정된 파일

- `operation-auth/src/main/java/org/sopt/makers/operation/config/SecurityConfig.java`

## 🧪 테스트

- [x] `./gradlew :operation-auth:compileJava` 성공
- [x] `./gradlew :operation-api:lambdaJar -x test` 성공
- [x] 기존 dev/prod 프로파일 영향 없음

## ⚠️ 주의사항

- [x] Breaking Change 없음
- [x] 기존 CI/CD 파이프라인 영향 없음
- [x] 기존 Security 설정 동작 변경 없음

## 📚 참고

- 기존 SecurityConfig.java 설정 유지
- Lambda 마이그레이션 Epic #[Epic 이슈번호]